### PR TITLE
Update service worker cache strategy

### DIFF
--- a/src/Uno.Wasm.Bootstrap/ShellTask.cs
+++ b/src/Uno.Wasm.Bootstrap/ShellTask.cs
@@ -181,10 +181,13 @@ namespace Uno.Wasm.Bootstrap
 		{
 			// The service worker file must change to be reloaded properly, add the dist digest
 			// as cache trasher.
-			var workerBody = File.ReadAllText(Path.Combine(_distPath, "service-worker.js"));
+			var workerFilePath = Path.Combine(_distPath, "service-worker.js");
+			var workerBody = File.ReadAllText(workerFilePath);
 
 			workerBody = workerBody.Replace("$(CACHE_KEY)", Path.GetFileName(_managedPath));
 			workerBody += $"\r\n\r\n// {Path.GetFileName(_managedPath)}";
+
+			File.WriteAllText(workerFilePath, workerBody);
 		}
 
 		/// <summary>
@@ -907,7 +910,7 @@ namespace Uno.Wasm.Bootstrap
 				config.AppendLine($"config.files_integrity = {{{filesIntegrityStr}}};");
 				config.AppendLine($"config.total_assemblies_size = {totalAssembliesSize};");
 				config.AppendLine($"config.enable_pwa = {enablePWA.ToString().ToLowerInvariant()};");
-				config.AppendLine($"config.offline_files = [{offlineFiles}];");
+				config.AppendLine($"config.offline_files = ['./', {offlineFiles}];");
 
 				config.AppendLine($"config.environmentVariables = config.environmentVariables || {{}};");
 

--- a/src/Uno.Wasm.Bootstrap/ShellTask.cs
+++ b/src/Uno.Wasm.Bootstrap/ShellTask.cs
@@ -181,10 +181,10 @@ namespace Uno.Wasm.Bootstrap
 		{
 			// The service worker file must change to be reloaded properly, add the dist digest
 			// as cache trasher.
-			using (var stream = new StreamWriter(File.Open(Path.Combine(_distPath, "service-worker.js"), FileMode.Append)))
-			{
-				stream.WriteLine($"// {Path.GetFileName(_managedPath)}");
-			}
+			var workerBody = File.ReadAllText(Path.Combine(_distPath, "service-worker.js"));
+
+			workerBody = workerBody.Replace("$(CACHE_KEY)", Path.GetFileName(_managedPath));
+			workerBody += $"\r\n\r\n// {Path.GetFileName(_managedPath)}";
 		}
 
 		/// <summary>

--- a/src/Uno.Wasm.Bootstrap/WasmScripts/service-worker.js
+++ b/src/Uno.Wasm.Bootstrap/WasmScripts/service-worker.js
@@ -5,7 +5,7 @@ let config = {};
 self.addEventListener('install', function (e) {
     console.debug('[ServiceWorker] Installing offline worker');
     e.waitUntil(
-        fetch("/uno-config.js")
+        fetch("./uno-config.js")
             .then(r => r.text()
                 .then(configStr => {
                     eval(configStr);

--- a/src/Uno.Wasm.Bootstrap/WasmScripts/service-worker.js
+++ b/src/Uno.Wasm.Bootstrap/WasmScripts/service-worker.js
@@ -30,7 +30,9 @@ self.addEventListener('fetch', event => {
             // cache content if needed.
             return await fetch(event.request);
         } catch (err) {
-            return caches.match(event.request, { ignoreSearch: true });
+            return caches.match(event.request).then(response => {
+                return response || fetch(event.request);
+            });
         }
     }());
 });

--- a/src/Uno.Wasm.Bootstrap/WasmScripts/uno-bootstrap.js
+++ b/src/Uno.Wasm.Bootstrap/WasmScripts/uno-bootstrap.js
@@ -494,10 +494,19 @@ if (typeof window === 'object' /* ENVIRONMENT_IS_WEB */) {
     document.addEventListener("DOMContentLoaded", () => App.preInit());
 
     if (config.enable_pwa && 'serviceWorker' in navigator) {
-        console.log('Registering service worker now');
-        navigator.serviceWorker.register('./service-worker.js')
-            .then(function () {
-                console.log('Service Worker Registered');
-            });
+        if (navigator.serviceWorker.controller) {
+            console.debug("Active service worker found, skipping register");
+        } else {
+            console.debug('Registering service worker now');
+
+            navigator.serviceWorker
+                .register(
+                    './service-worker.js', {
+                        scope: "./"
+                    })
+                .then(function () {
+                    console.debug('Service Worker Registered');
+                });
+        }
     }
 }

--- a/src/Uno.Wasm.Bootstrap/WasmScripts/uno-bootstrap.js
+++ b/src/Uno.Wasm.Bootstrap/WasmScripts/uno-bootstrap.js
@@ -495,7 +495,7 @@ if (typeof window === 'object' /* ENVIRONMENT_IS_WEB */) {
 
     if (config.enable_pwa && 'serviceWorker' in navigator) {
         console.log('Registering service worker now');
-        navigator.serviceWorker.register('/service-worker.js')
+        navigator.serviceWorker.register('./service-worker.js')
             .then(function () {
                 console.log('Service Worker Registered');
             });


### PR DESCRIPTION
- Use fetch then cache strategy
- Use literal cache version to avoid using already cached version even if the service got updated