### PR TITLE
Add azure publish long path error fallback

### DIFF
--- a/src/Uno.Wasm.Bootstrap/Extensions/LongPathHelper.cs
+++ b/src/Uno.Wasm.Bootstrap/Extensions/LongPathHelper.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Uno.Wasm.Bootstrap.Extensions
+{
+	public static class FileInfoExtensions
+	{
+		public static bool PlatformRequiresLongPathNormalization { get; } = CheckIfNeedToNormalizeLongPaths();
+
+		// https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfullpathnamea
+		[DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+		private static extern uint GetFullPathName(string lpFileName, uint nBufferLength, StringBuilder lpBuffer, IntPtr lpFilePart);
+
+		private static bool CheckIfNeedToNormalizeLongPaths()
+		{
+			if (Type.GetType("Mono.Runtime") != null)
+			{
+				return false;
+			}
+
+			if (RuntimeInformation.FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase))
+			{
+				return false; // no need to normalize long paths on .net core
+			}
+
+			switch (Environment.OSVersion.Platform)
+			{
+				case PlatformID.Win32NT:
+				case PlatformID.Win32S:
+				case PlatformID.Win32Windows:
+					return true;
+			}
+
+			return false;
+		}
+
+
+		public static string GetNormalizedLongPath(this string fileName)
+		{
+			if (PlatformRequiresLongPathNormalization)
+			{
+				if (fileName.StartsWith(@"\\?"))
+				{
+					return fileName; // already normalized
+				}
+
+				var sb = new StringBuilder(fileName.Length + 1);
+				var length = GetFullPathName(fileName, (uint)sb.Capacity, sb, IntPtr.Zero);
+
+				if (length > sb.Capacity)
+				{
+					// https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfullpathnamea#return-value
+					sb.Capacity = (int)length; // increase capacity
+					length = GetFullPathName(fileName, (uint)sb.Capacity, sb, IntPtr.Zero);
+				}
+
+				if (length < 260)
+				{
+					return sb.ToString();
+				}
+
+				return @"\\?\" + sb;
+			}
+
+			return fileName;
+		}
+	}
+}

--- a/src/Uno.Wasm.Bootstrap/ShellTask.cs
+++ b/src/Uno.Wasm.Bootstrap/ShellTask.cs
@@ -168,6 +168,25 @@ namespace Uno.Wasm.Bootstrap
 
 		private void TryEnableLongPathAware()
 		{
+			if (EnableLongPathSupport)
+			{
+				// In some cases, particularly when using the Azure publish task
+				// long paths using the "\\?\" prefix is not supported. Fallback on
+				// standard paths in such cases.
+
+				try
+				{
+					var path = TryConvertLongPath(Path.GetFullPath(DistPath));
+
+					DirectoryCreateDirectory(path);
+				}
+				catch (ArgumentException e)
+				{
+					Log.LogMessage($"Long path format use failed, falling back to standard path (Error: {e.Message})") ;
+					EnableLongPathSupport = false;
+				}
+			}
+
 			IntermediateOutputPath = TryConvertLongPath(IntermediateOutputPath);
 			DistPath = TryConvertLongPath(DistPath);
 			MonoTempFolder = TryConvertLongPath(MonoTempFolder);
@@ -221,7 +240,7 @@ namespace Uno.Wasm.Bootstrap
 			}
 			catch(Exception e)
 			{
-				Log.LogError($"Failed to create directory {directoryName}");
+				Log.LogError($"Failed to create directory [{directoryName}][{directory}]");
 				throw;
 			}
 		}

--- a/src/Uno.Wasm.Bootstrap/ShellTask.cs
+++ b/src/Uno.Wasm.Bootstrap/ShellTask.cs
@@ -31,6 +31,7 @@ using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;
 using Mono.Cecil;
 using Newtonsoft.Json.Linq;
+using Uno.Wasm.Bootstrap.Extensions;
 
 namespace Uno.Wasm.Bootstrap
 {
@@ -585,9 +586,9 @@ namespace Uno.Wasm.Bootstrap
 				&& !path.StartsWith(@"\\?\")
 				&& Path.IsPathRooted(path)
 				&& EnableLongPathSupport
+				&& FileInfoExtensions.PlatformRequiresLongPathNormalization
 				? @"\\?\" + path
 				: path;
-
 		private static string ValidateEmscripten()
 		{
 			var emsdkPath = Environment.GetEnvironmentVariable("EMSDK");

--- a/src/Uno.Wasm.Bootstrap/Uno.Wasm.Bootstrap.csproj
+++ b/src/Uno.Wasm.Bootstrap/Uno.Wasm.Bootstrap.csproj
@@ -41,7 +41,7 @@
 			<Pack>true</Pack>
 			<PackagePath>build</PackagePath>
 		</Content>
-		<Content Include="build\packager\**">
+		<Content Include="build/packager/**">
 			<Pack>true</Pack>
 			<PackagePath>build/packager</PackagePath>
 		</Content>

--- a/src/Uno.Wasm.Bootstrap/Uno.Wasm.Bootstrap.csproj
+++ b/src/Uno.Wasm.Bootstrap/Uno.Wasm.Bootstrap.csproj
@@ -13,11 +13,11 @@
 
 	<PropertyGroup>
 		<Authors>nventive</Authors>
-		<PackageProjectUrl>https://github.com/nventive/Uno.Wasm.Bootstrap</PackageProjectUrl>
+		<PackageProjectUrl>https://github.com/unoplatform/Uno.Wasm.Bootstrap</PackageProjectUrl>
 		<PackageIconUrl>https://nv-assets.azurewebsites.net/logos/uno.png</PackageIconUrl>
-		<RepositoryUrl>https://github.com/nventive/Uno.Wasm.Bootstrap</RepositoryUrl>
+		<RepositoryUrl>https://github.com/unoplatform/Uno.Wasm.Bootstrap</RepositoryUrl>
 		<Description>This package provides a Wasm bootstrap for netstandard 2.0 projects.</Description>
-		<Copyright>Copyright (C) 2015-2018 nventive inc. - all rights reserved</Copyright>
+		<Copyright>Copyright (C) 2015-$([System.DateTime]::Now.ToString(`yyyy`)) nventive inc. - all rights reserved</Copyright>
 	</PropertyGroup>
 	
 	<ItemGroup>
@@ -40,10 +40,6 @@
 		<Content Include="build/*.props">
 			<Pack>true</Pack>
 			<PackagePath>build</PackagePath>
-		</Content>
-		<Content Include="build/packager/**">
-			<Pack>true</Pack>
-			<PackagePath>build/packager</PackagePath>
 		</Content>
 		<Content Include="build/CustomDebuggerProxy/**">
 			<Pack>true</Pack>
@@ -130,8 +126,16 @@
 		<Copy SourceFiles="@(_PackagerSource)" DestinationFolder="$(_packagerIntermediatePath)" />
 		<Move SourceFiles="$(_packagerIntermediatePath)packager.proj" DestinationFiles="$(_packagerIntermediatePath)packager.csproj" />
 		<MSBuild Projects="$(_packagerIntermediatePath)packager.csproj" Targets="Restore;Build" Properties="Configuration=$(Configuration)" />
-		<Copy SourceFiles="$(_packagerIntermediatePath)bin/$(Configuration)/packager.exe" DestinationFiles="build/packager/packager2.exe" />
-		<Copy SourceFiles="$(_packagerIntermediatePath)bin/$(Configuration)/Mono.Cecil.dll" DestinationFolder="build/packager" />
+		<Copy SourceFiles="$(_packagerIntermediatePath)bin/$(Configuration)/packager.exe" DestinationFiles="$(MSBuildThisFileDirectory)build/packager/packager2.exe" />
+		<Copy SourceFiles="$(_packagerIntermediatePath)bin/$(Configuration)/Mono.Cecil.dll" DestinationFolder="$(MSBuildThisFileDirectory)build/packager" />
+
+		<!-- Update the item group with generated files -->
+		<ItemGroup>
+			<Content Include="build/packager/**">
+				<Pack>true</Pack>
+				<PackagePath>build/packager</PackagePath>
+			</Content>
+		</ItemGroup>
 	</Target>
 
 </Project>


### PR DESCRIPTION
When using the VS 2019 Azure WebApp publication, long path support seems to be disabled by the hosting msbuild executable.

This PR disables long path generation if it is not supported by the current process.

This PR fixes https://github.com/unoplatform/uno/issues/2463.