### PR TITLE
feat: Add Uno.Wasm.Bootstrap.DevServer package

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,13 +20,12 @@ This package is based on the excellent work from @praeclarum's [OOui Wasm MSBuil
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <MonoRuntimeDebuggerEnabled>false</MonoRuntimeDebuggerEnabled>
+    <MonoRuntimeDebuggerEnabled Condition="'$(Configuration)'=='Debug'">true</MonoRuntimeDebuggerEnabled>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Uno.Wasm.Bootstrap" Version="1.1.0-dev.1" />
-
-    <DotNetCliToolReference Include="Uno.Wasm.Bootstrap.Cli" Version="1.1.0-dev.1" />
+    <PackageReference Include="Uno.Wasm.Bootstrap" Version="1.2.0-dev.1" />
+    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="1.2.0-dev.1" PrivateAssets="all" />
  </ItemGroup>
 
 </Project>
@@ -55,7 +54,11 @@ See below the instructions on how to install the **Windows Subsystem for Linux**
 ### Upgrading from previous versions of the Uno.Wasm.Bootstrap package
 Previously, the suggested project structure was a .NET Standard 2.0 project using the non-web projects SDK. To enable debugging and easier deployment, the support for `Microsoft.NET.Sdk.Web` has been added.
 
-To upgrade a project:
+To upgrade a project from 1.1 to 1.2:
+- If you had a `<DotNetCliToolReference />` line, remove it
+- Add the `<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="1.2.0-dev.1" PrivateAssets="all" />` item in the same item group as the other nuget packages.
+
+To upgrade a project from 1.0 to 1.1:
 - Change `Microsoft.NET.Sdk` to `Microsoft.NET.Sdk.Web` in the Sdk attribute of your project
 - Add the `<DotNetCliToolReference Include="Uno.Wasm.Bootstrap.Cli" Version="1.0.0-dev.1" />` item in the same item group as the other nuget packages.
 

--- a/src/LongPathTest/Uno.Wasm.LongPath.csproj
+++ b/src/LongPathTest/Uno.Wasm.LongPath.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <Import Project="..\Uno.Wasm.Bootstrap\build\Uno.Wasm.Bootstrap.targets" />
+	<Import Project="..\Uno.Wasm.Bootstrap.DevServer\build\Uno.Wasm.Bootstrap.DevServer.targets" />
 	
 	<ItemGroup>
 		<ProjectReference Include="..\Uno.Wasm.Bootstrap\Uno.Wasm.Bootstrap.csproj">

--- a/src/Uno.Wasm.AotTests/Uno.Wasm.AotTests.csproj
+++ b/src/Uno.Wasm.AotTests/Uno.Wasm.AotTests.csproj
@@ -12,6 +12,7 @@
 	</PropertyGroup>
 
 	<Import Project="..\Uno.Wasm.Bootstrap\build\Uno.Wasm.Bootstrap.targets" />
+	<Import Project="..\Uno.Wasm.Bootstrap.DevServer\build\Uno.Wasm.Bootstrap.DevServer.targets" />
 
 	<ItemGroup>
 		<None Remove="Uno.Wasm.AotTests.xml" />

--- a/src/Uno.Wasm.Bootstrap.Cli/Uno.Wasm.Bootstrap.Cli.csproj
+++ b/src/Uno.Wasm.Bootstrap.Cli/Uno.Wasm.Bootstrap.Cli.csproj
@@ -5,19 +5,8 @@
     <StartupObject>Uno.Wasm.Bootstrap.Cli.Program</StartupObject>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>dotnet-unowasm</AssemblyName>
-    <PackageId>Uno.Wasm.Bootstrap.Cli</PackageId>
-		<IsPackable>true</IsPackable>
-		<GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
+		<IsPackable>false</IsPackable>
 	</PropertyGroup>
-
-  <PropertyGroup>
-    <Authors>nventive</Authors>
-    <PackageProjectUrl>https://github.com/nventive/Uno.Wasm.Bootstrap</PackageProjectUrl>
-    <PackageIconUrl>https://nv-assets.azurewebsites.net/logos/uno.png</PackageIconUrl>
-    <RepositoryUrl>https://github.com/nventive/Uno.Wasm.Bootstrap</RepositoryUrl>
-    <Description>This package provides CLI support for Wasm bootstrap projects</Description>
-    <Copyright>Copyright (C) 2015-$([System.DateTime]::Now.ToString(`yyyy`)) nventive inc. - all rights reserved</Copyright>
-  </PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.2" />

--- a/src/Uno.Wasm.Bootstrap.DevServer/Uno.Wasm.Bootstrap.DevServer.csproj
+++ b/src/Uno.Wasm.Bootstrap.DevServer/Uno.Wasm.Bootstrap.DevServer.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<NoWarn>1701;1702;1705;649</NoWarn>
+		<PackageId>Uno.Wasm.Bootstrap.DevServer</PackageId>
+		<IsTool>true</IsTool>
+		<IncludeBuildOutput>false</IncludeBuildOutput>
+		<GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<Authors>nventive</Authors>
+		<PackageProjectUrl>https://github.com/nventive/Uno.Wasm.Bootstrap</PackageProjectUrl>
+		<PackageIconUrl>https://nv-assets.azurewebsites.net/logos/uno.png</PackageIconUrl>
+		<RepositoryUrl>https://github.com/nventive/Uno.Wasm.Bootstrap</RepositoryUrl>
+		<Description>This package provides the development server and debugger support for Wasm bootstrap projects</Description>
+		<Copyright>Copyright (C) 2015-$([System.DateTime]::Now.ToString(`yyyy`)) nventive inc. - all rights reserved</Copyright>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<Content Include="build\Uno.Wasm.Bootstrap.DevServer.targets">
+			<PackagePath>build</PackagePath>
+			<Pack>true</Pack>
+		</Content>
+		<Content Include="..\Uno.Wasm.Bootstrap.Cli\bin\$(Configuration)\netcoreapp3.1\*.*" Link="tools\server\%(FileName)%(Extension)">
+			<PackagePath>tools\server</PackagePath>
+			<Pack>true</Pack>
+		</Content>
+	</ItemGroup>
+
+</Project>

--- a/src/Uno.Wasm.Bootstrap.DevServer/build/Uno.Wasm.Bootstrap.DevServer.targets
+++ b/src/Uno.Wasm.Bootstrap.DevServer/build/Uno.Wasm.Bootstrap.DevServer.targets
@@ -1,0 +1,16 @@
+﻿<Project>
+
+  <PropertyGroup>
+	<!-- Web Project Run Parameters -->
+	<RunCommand>dotnet</RunCommand>
+
+	<!-- Nuget deployed run parameters -->
+	<_unoBinArgs>unowasm serve</_unoBinArgs>
+
+	<!-- Uno.Wasm.Bootstrap internal args -->
+	<_unoBinArgs Condition="exists('$(MSBuildThisFileDirectory)../../Uno.Wasm.Bootstrap.Cli')">exec &quot;$(MSBuildThisFileDirectory)../../Uno.Wasm.Bootstrap.Cli/bin/$(Configuration)/netcoreapp3.1/dotnet-unowasm.dll&quot; serve $(_unoRunArgs)</_unoBinArgs>
+	<_unoBinArgs Condition="!exists('$(MSBuildThisFileDirectory)../../Uno.Wasm.Bootstrap.Cli')">&quot;$(MSBuildThisFileDirectory)../tools/server/dotnet-unowasm.dll&quot; serve $(_unoRunArgs)</_unoBinArgs>
+	<RunArguments>$(_unoBinArgs) $(_unoRunArgs) --pathbase &quot;$(MSBuildProjectDirectory)\bin\$(Configuration)\$(TargetFramework)\dist&quot; --configuration $(Configuration) --targetframework $(TargetFramework) $(AdditionalRunArguments)</RunArguments>
+  </PropertyGroup>
+
+</Project>

--- a/src/Uno.Wasm.Bootstrap.sln
+++ b/src/Uno.Wasm.Bootstrap.sln
@@ -52,6 +52,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.Wasm.Threads", "Uno.Was
 EndProject
 Project("{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}") = "Uno.Wasm.Threading.UITests", "Uno.Wasm.Threading.UITests\Uno.Wasm.Threading.UITests.njsproj", "{3D59ACEE-12BF-4B69-AEF7-893514C0BA7D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.Wasm.Bootstrap.DevServer", "Uno.Wasm.Bootstrap.DevServer\Uno.Wasm.Bootstrap.DevServer.csproj", "{6ACB62AD-0DFF-4593-A7EC-5A4E21DA4ABE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -130,6 +132,10 @@ Global
 		{3D59ACEE-12BF-4B69-AEF7-893514C0BA7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3D59ACEE-12BF-4B69-AEF7-893514C0BA7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3D59ACEE-12BF-4B69-AEF7-893514C0BA7D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6ACB62AD-0DFF-4593-A7EC-5A4E21DA4ABE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6ACB62AD-0DFF-4593-A7EC-5A4E21DA4ABE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6ACB62AD-0DFF-4593-A7EC-5A4E21DA4ABE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6ACB62AD-0DFF-4593-A7EC-5A4E21DA4ABE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Uno.Wasm.Bootstrap/ShellTask.cs
+++ b/src/Uno.Wasm.Bootstrap/ShellTask.cs
@@ -91,6 +91,9 @@ namespace Uno.Wasm.Bootstrap
 		public string TargetFrameworkIdentifier { get; set; }
 
 		[Microsoft.Build.Framework.Required]
+		public string TargetFramework { get; set; }
+
+		[Microsoft.Build.Framework.Required]
 		public string IndexHtmlPath { get; set; }
 
 		[Required]
@@ -145,7 +148,7 @@ namespace Uno.Wasm.Bootstrap
 		{
 			try
 			{
-				if (TargetFrameworkIdentifier != ".NETStandard")
+				if (TargetFrameworkIdentifier != ".NETStandard" && TargetFrameworkIdentifier != ".NETCoreApp")
 				{
 					Log.LogWarning($"The package Uno.Wasm.Bootstrap is not supported for the current project ({Assembly}), skipping dist generation.");
 					return true;

--- a/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
+++ b/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
@@ -54,17 +54,6 @@
 
     <!-- Compatibility with previous version of the task using WasmShellEnableAOT -->
     <WasmShellMonoRuntimeExecutionMode Condition="'$(WasmShellEnableAOT)'=='true'">FullAOT</WasmShellMonoRuntimeExecutionMode>
-
-    <!-- Web Project Run Parameters -->
-    <RunCommand>dotnet</RunCommand>
-    <!-- Nuget deployed run parameters -->
-    <_unoBinArgs>unowasm serve</_unoBinArgs>
-    <!-- Uno.Wasm.Bootstrap internal args -->
-    <_unoBinArgs Condition="exists('$(MSBuildThisFileDirectory)../../Uno.Wasm.Bootstrap.Cli')">exec &quot;$(MSBuildThisFileDirectory)../../Uno.Wasm.Bootstrap.Cli/bin/$(Configuration)/netcoreapp3.1/dotnet-unowasm.dll&quot; serve $(_unoRunArgs)</_unoBinArgs>
-    <RunArguments>$(_unoBinArgs) $(_unoRunArgs) --pathbase &quot;$(MSBuildProjectDirectory)\bin\$(Configuration)\$(TargetFramework)\dist&quot; --configuration $(Configuration) --targetframework $(TargetFramework) $(AdditionalRunArguments)</RunArguments>
-
-	<!-- Force the Cli tool framework if not specified (2.2 by default as of VS2019 16.6 Pre 1 -->
-	<DotnetCliToolTargetFramework Condition="'$(DotnetCliToolTargetFramework)'==''">netcoreapp3.1</DotnetCliToolTargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -140,6 +129,7 @@
         BaseIntermediateOutputPath="$(BaseIntermediateOutputPath)"
         IntermediateOutputPath="$(ProjectDir)$(IntermediateOutputPath)"
         TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
+        TargetFramework="$(TargetFramework)"
         WasmShellMode="$(WasmShellMode)"
         MonoWasmSDKPath="$(_UnoMonoSdkPath)"
         PackagerBinPath="$(_UnoMonoPackagerBinPath)"

--- a/src/Uno.Wasm.DynamicLinking/Uno.Wasm.DynamicLinking.csproj
+++ b/src/Uno.Wasm.DynamicLinking/Uno.Wasm.DynamicLinking.csproj
@@ -16,6 +16,7 @@
 	</ItemGroup>
 
 	<Import Project="..\Uno.Wasm.Bootstrap\build\Uno.Wasm.Bootstrap.targets" />
+	<Import Project="..\Uno.Wasm.Bootstrap.DevServer\build\Uno.Wasm.Bootstrap.DevServer.targets" />
 
 	<ItemGroup>
 		<None Include="WasmScripts\**\*.js" />

--- a/src/Uno.Wasm.MixedModeRoslynSample/Uno.Wasm.MixedModeRoslynSample.csproj
+++ b/src/Uno.Wasm.MixedModeRoslynSample/Uno.Wasm.MixedModeRoslynSample.csproj
@@ -24,6 +24,7 @@
 	</ItemGroup>
 
 	<Import Project="..\Uno.Wasm.Bootstrap\build\Uno.Wasm.Bootstrap.targets" />
+	<Import Project="..\Uno.Wasm.Bootstrap.DevServer\build\Uno.Wasm.Bootstrap.DevServer.targets" />
 
 	<ItemGroup>
 		<None Include="WasmScripts\**\*.js" />

--- a/src/Uno.Wasm.MixedModeSample/Uno.Wasm.MixedModeSample.csproj
+++ b/src/Uno.Wasm.MixedModeSample/Uno.Wasm.MixedModeSample.csproj
@@ -20,6 +20,7 @@
 	</ItemGroup>
 
 	<Import Project="..\Uno.Wasm.Bootstrap\build\Uno.Wasm.Bootstrap.targets" />
+	<Import Project="..\Uno.Wasm.Bootstrap.DevServer\build\Uno.Wasm.Bootstrap.DevServer.targets" />
 
 	<ItemGroup>
 		<None Include="WasmScripts\**\*.js" />

--- a/src/Uno.Wasm.Node.Sample/Uno.Wasm.Node.Sample.csproj
+++ b/src/Uno.Wasm.Node.Sample/Uno.Wasm.Node.Sample.csproj
@@ -15,6 +15,7 @@
 	</ItemGroup>
 
 	<Import Project="..\Uno.Wasm.Bootstrap\build\Uno.Wasm.Bootstrap.targets" />
+	<Import Project="..\Uno.Wasm.Bootstrap.DevServer\build\Uno.Wasm.Bootstrap.DevServer.targets" />
 
 	<ItemGroup>
 		<None Include="WasmScripts\**\*.js" />
@@ -43,6 +44,11 @@
 			<UndefineProperties>TargetFramework</UndefineProperties>
 		</ProjectReference>
 		<ProjectReference Include="..\Uno.Wasm.Bootstrap.Cli\Uno.Wasm.Bootstrap.Cli.csproj">
+			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+			<SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+			<UndefineProperties>TargetFramework</UndefineProperties>
+		</ProjectReference>
+		<ProjectReference Include="..\Uno.Wasm.Bootstrap.DevServer\Uno.Wasm.Bootstrap.DevServer.csproj">
 			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
 			<SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
 			<UndefineProperties>TargetFramework</UndefineProperties>

--- a/src/Uno.Wasm.Sample/Uno.Wasm.Sample.csproj
+++ b/src/Uno.Wasm.Sample/Uno.Wasm.Sample.csproj
@@ -15,6 +15,7 @@
 	</ItemGroup>
 
 	<Import Project="..\Uno.Wasm.Bootstrap\build\Uno.Wasm.Bootstrap.targets" />
+	<Import Project="..\Uno.Wasm.Bootstrap.DevServer\build\Uno.Wasm.Bootstrap.DevServer.targets" />
 
 	<ItemGroup>
 		<None Include="WasmScripts\**\*.js" />

--- a/src/Uno.Wasm.Tests.Electron/Uno.Wasm.Tests.Electron.csproj
+++ b/src/Uno.Wasm.Tests.Electron/Uno.Wasm.Tests.Electron.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
 
   <Import Project="..\Uno.Wasm.Bootstrap\build\Uno.Wasm.Bootstrap.targets" />
+	<Import Project="..\Uno.Wasm.Bootstrap.DevServer\build\Uno.Wasm.Bootstrap.DevServer.targets" />
 	
 	<ItemGroup>
 		<ProjectReference Include="..\Uno.Wasm.Bootstrap.Cli\Uno.Wasm.Bootstrap.Cli.csproj">

--- a/src/Uno.Wasm.Tests.Empty/Uno.Wasm.Test.Empty.csproj
+++ b/src/Uno.Wasm.Tests.Empty/Uno.Wasm.Test.Empty.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <Import Project="..\Uno.Wasm.Bootstrap\build\Uno.Wasm.Bootstrap.targets" />
+	<Import Project="..\Uno.Wasm.Bootstrap.DevServer\build\Uno.Wasm.Bootstrap.DevServer.targets" />
 	
 	<ItemGroup>
 		<ProjectReference Include="..\Uno.Wasm.Bootstrap.Cli\Uno.Wasm.Bootstrap.Cli.csproj">

--- a/src/Uno.Wasm.Tests.TypeScript/Uno.Wasm.Tests.TypeScript.csproj
+++ b/src/Uno.Wasm.Tests.TypeScript/Uno.Wasm.Tests.TypeScript.csproj
@@ -33,6 +33,7 @@
   </ItemGroup>
 
   <Import Project="..\Uno.Wasm.Bootstrap\build\Uno.Wasm.Bootstrap.targets" />
+	<Import Project="..\Uno.Wasm.Bootstrap.DevServer\build\Uno.Wasm.Bootstrap.DevServer.targets" />
 	
 	<ItemGroup>
 		<ProjectReference Include="..\Uno.Wasm.Bootstrap.Cli\Uno.Wasm.Bootstrap.Cli.csproj">

--- a/src/Uno.Wasm.Threads/Uno.Wasm.Threads.csproj
+++ b/src/Uno.Wasm.Threads/Uno.Wasm.Threads.csproj
@@ -18,6 +18,7 @@
 	</ItemGroup>
 
 	<Import Project="..\Uno.Wasm.Bootstrap\build\Uno.Wasm.Bootstrap.targets" />
+	<Import Project="..\Uno.Wasm.Bootstrap.DevServer\build\Uno.Wasm.Bootstrap.DevServer.targets" />
 
 	<ItemGroup>
 		<None Include="WasmScripts\**\*.js" />

--- a/src/Uno.WasmSample WithSpace/Uno.WasmSample.WithSpace.csproj
+++ b/src/Uno.WasmSample WithSpace/Uno.WasmSample.WithSpace.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <Import Project="..\Uno.Wasm.Bootstrap\build\Uno.Wasm.Bootstrap.targets" />
+	<Import Project="..\Uno.Wasm.Bootstrap.DevServer\build\Uno.Wasm.Bootstrap.DevServer.targets" />
 	
 	<ItemGroup>
 		<ProjectReference Include="..\Uno.Wasm.Bootstrap.Cli\Uno.Wasm.Bootstrap.Cli.csproj">


### PR DESCRIPTION
BREAKING CHANGE: The `Uno.Wasm.Bootstrap.Cli` package is now deprecated and needs to be replaced with `Uno.Wasm.Bootstrap.DevServer` see the documentation for more details.

This change fixes #186, as there is no dotnet-tool to run anymore.