### PR TITLE
fix: Fail the build when a project uses the deprecated CLI package

### DIFF
--- a/.vsts-ci-linux.yml
+++ b/.vsts-ci-linux.yml
@@ -1,7 +1,7 @@
 parameters:
   jobName: ''
   linux_container: ''
-  linux_vmImage: 'ubuntu-18.04'
+  linux_vmImage: 'ubuntu-latest'
   netcore_version: ''
 
 jobs:
@@ -85,6 +85,9 @@ jobs:
       CleanTargetFolder: false
       OverWrite: false
       flattenFolders: false
+
+  - bash: rm -fr ~/emsdk
+    displayName: Cleanup Emscripten folder to run tests
 
   - bash: |
       cd $(build.sourcesdirectory)/src/Uno.Wasm.AotTests/bin/Release/netstandard2.0/dist

--- a/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
+++ b/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
@@ -165,8 +165,14 @@
     <Delete Files="@(_DistFilesToDelete)" />
   </Target>
 
+  <Target Name="_ValidateLegacyCLIPackage" BeforeTargets="CoreCompile">
+	<PropertyGroup>
+	  <_CliToolRefs>@(DotNetCliToolReference)</_CliToolRefs>
+	</PropertyGroup>
+
+	<Error Text="The current project is referencing the deprecated Uno.Wasm.Bootstrap.Cli package. Remove it manually in the project file and add a reference to Uno.Wasm.Bootstrap.DevServer instead. For more information visit: https://github.com/unoplatform/Uno.Wasm.Bootstrap#upgrading-from-previous-versions-of-the-unowasmbootstrap-package"
+		 Condition="$(_CliToolRefs.Contains('Uno.Wasm.Bootstrap.Cli'))"/>
+  </Target>
 
   <Import Project="Uno.Wasm.Bootstrap.Publish.targets"/>
-
-
 </Project>


### PR DESCRIPTION
Fixes https://github.com/unoplatform/uno/issues/2974