### PR TITLE
fix(debugger): Fix using bitcode files breaks the debugger

### DIFF
--- a/src/Uno.Wasm.Bootstrap/Packager/packager.cs
+++ b/src/Uno.Wasm.Bootstrap/Packager/packager.cs
@@ -84,6 +84,10 @@ class Driver {
 		public string aot_depfile_path;
 		// Linker input path
 		public string linkin_path;
+		// Linker pdb input path
+		public string linkin_pdb_path;
+		// Linker pdb output path
+		public string linkout_pdb_path;
 		// Linker output path
 		public string linkout_path;
 		// AOT input path
@@ -1082,13 +1086,22 @@ class Driver {
 			bool emit_pdb = assemblies_with_dbg_info.Contains (source_file_path_pdb);
 			if (enable_linker) {
 				a.linkin_path = $"$builddir/linker-in/{filename}";
+				a.linkin_pdb_path = $"$builddir/linker-in/{filename_pdb}";
 				a.linkout_path = $"$builddir/linker-out/{filename}";
+				a.linkout_pdb_path = $"$builddir/linker-out/{filename_pdb}";
+
 				linker_infiles += $"{a.linkin_path} ";
 				linker_ofiles += $" {a.linkout_path}";
+
 				if (a.aot) {
 					linker_ofiles_dedup += $" {a.linkout_path}";
 				}
 				ninja.WriteLine ($"build {a.linkin_path}: cp {source_file_path}");
+				if (File.Exists(source_file_path_pdb)) {
+					ninja.WriteLine($"build {a.linkin_pdb_path}: cp {source_file_path_pdb}");
+					linker_ofiles += $" {a.linkout_pdb_path}";
+					infile_pdb = a.linkout_pdb_path;
+				}
 				a.aotin_path = a.linkout_path;
 				infile = $"{a.aotin_path}";
 			} else {
@@ -1214,6 +1227,9 @@ class Driver {
 			if (!opts.EnableCollation) {
 				linker_args += "--substitutions linker-disable-collation.xml ";
 				linker_infiles += "linker-disable-collation.xml";
+			}
+			if (opts.Debug) {
+				linker_args += "-b true ";
 			}
 			if (!string.IsNullOrEmpty (linkDescriptor)) {
 				linker_args += $"-x {linkDescriptor} ";


### PR DESCRIPTION
The linker was not emitting the symbols from the linker-in path.

Fixes https://github.com/unoplatform/uno/issues/3150

An updated is posted in mono for the packager: https://github.com/mono/mono/pull/19863