### PR TITLE
fix: Adjust WSL mono install script instructions

### DIFF
--- a/src/Uno.Wasm.Bootstrap/ShellTask.cs
+++ b/src/Uno.Wasm.Bootstrap/ShellTask.cs
@@ -842,7 +842,7 @@ namespace Uno.Wasm.Bootstrap
 
 				Log.LogError(
 					$"The Windows Subsystem for Linux dotnet environment may not be properly setup, and you may need to run " +
-					$"the environment setup script. Open a Windows Command Prompt and run:\n\nbash -c `wslpath \"{dotnetSetupScript}\"`\n\n");
+					$"the environment setup script. Open an Ubuntu WSL shell and run:\n\nbash -c `wslpath \"{dotnetSetupScript}\"`\n\n");
 
 				throw new InvalidOperationException($"Failed to setup WSL environment.");
 			}


### PR DESCRIPTION
The instructions were incorrectly mentioning the Windows command prompt, instead of the WSL shell.