### PR TITLE
Add DynamicLibraries option (to make __Internal pinvokes possible)

### DIFF
--- a/src/Uno.Wasm.Bootstrap/UnoInstallSDKTask.cs
+++ b/src/Uno.Wasm.Bootstrap/UnoInstallSDKTask.cs
@@ -32,6 +32,7 @@ namespace Uno.Wasm.Bootstrap
 
 		[Microsoft.Build.Framework.Required]
 		public Microsoft.Build.Framework.ITaskItem[]? Assets { get; set; }
+		public Microsoft.Build.Framework.ITaskItem[]? DynamicLibraries { get; set; }
 
 		public bool GenerateAOTProfile { get; set; } = false;
 
@@ -107,6 +108,7 @@ namespace Uno.Wasm.Bootstrap
 					runtimeExecutionMode == RuntimeExecutionMode.FullAOT
 					|| runtimeExecutionMode == RuntimeExecutionMode.InterpreterAndAOT
 					|| HasBitcodeAssets()
+					|| HasDynamicLibraries()
 					|| GenerateAOTProfile
 					)
 					&& !Directory.Exists(Path.Combine(SdkPath, "wasm-cross-release"))
@@ -159,6 +161,9 @@ namespace Uno.Wasm.Bootstrap
 
 		private bool HasBitcodeAssets()
 			=> Assets.Any(asset => BitCodeExtensions.Any(ext => asset.ItemSpec.EndsWith(ext, StringComparison.OrdinalIgnoreCase)));
+
+		private bool HasDynamicLibraries()
+			=> DynamicLibraries?.Any() ?? false;
 
 		private string RetreiveSDKFile(string sdkName, string sdkUri, string zipPath)
 		{

--- a/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
+++ b/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
@@ -146,6 +146,7 @@
         MonoEnvironment="@(WasmShellMonoEnvironment)"
         MonoRuntimeExecutionMode="$(WasmShellMonoRuntimeExecutionMode)"
         MixedModeExcludedAssembly="@(MonoRuntimeMixedModeExcludedAssembly)"
+        DynamicLibraries="@(WasmShellDynamicLibraries)"
         ExtraEmccFlags="@(WasmShellExtraEmccFlags)"
         MonoILLinker="$(WasmShellILLinkerEnabled)"
         MonoTempFolder="$(WasmShellMonoTempFolder)"


### PR DESCRIPTION
Currently, you can only pinvoke native libraries.
This PR will make it possible to pinvoke internal emscripten functions like this:

Just add this to your csproj file:
```xml
<WasmShellDynamicLibraries Import="__Internal_emscripten"/>
```
And thats it! Now you can use emscripten:
```csharp
[DllImport("__Internal_emscripten")]
public static extern void emscripten_console_log(string str);
```
In this example `__Internal_emscripten` is a configurable name that is an alias for `__Internal`, because `__Internal` cannot be used directly (because of mono restrictions).