### PR TITLE
fix: Restore metadata for parameter names

### DIFF
--- a/src/Uno.Wasm.Bootstrap/ShellTask.cs
+++ b/src/Uno.Wasm.Bootstrap/ShellTask.cs
@@ -830,6 +830,9 @@ namespace Uno.Wasm.Bootstrap
 					// Opts should be aligned with the monolinker call in packager.cs, validate for linker_args as well
 					var packagerLinkerOpts = $"--deterministic --disable-opt unreachablebodies --used-attrs-only true ";
 
+					// Metadata linking https://github.com/mono/linker/commit/fafb6cf6a385a8c753faa174b9ab7c3600a9d494
+					packagerLinkerOpts += "--keep-metadata all ";
+
 					packagerLinkerOpts += GetLinkerFeatureConfiguration();
 
 					var linkerResults = RunProcess(

--- a/src/Uno.Wasm.Packager/packager.cs
+++ b/src/Uno.Wasm.Packager/packager.cs
@@ -1489,6 +1489,9 @@ class Driver {
 			}
 			linker_args += $"-d linker-in -d $bcl_dir -d $bcl_facades_dir -d $framework_dir ";
 
+			// Metadata linking https://github.com/mono/linker/commit/fafb6cf6a385a8c753faa174b9ab7c3600a9d494
+			linker_args += $"--keep-metadata all ";
+
 			if (!is_netcore) {
 				linker_args += $" -c {coremode} -u {usermode} ";
 			}


### PR DESCRIPTION
Restores linker original behavior of keeping parameter names even if unused. This can break reflection based algorithms in very subtle ways (MonacoEditor is one)