### PR TITLE
feat: Add `-emit-llvm` flag to improve AOT build performance

### DIFF
--- a/src/Uno.Wasm.Packager/packager.cs
+++ b/src/Uno.Wasm.Packager/packager.cs
@@ -1022,6 +1022,7 @@ class Driver {
 		}
 		if (is_netcore) {
 			emcc_flags += $"-DGEN_PINVOKE -I{src_prefix} ";
+			emcc_flags += $"-emit-llvm ";
 		}
 		if (!use_release_runtime)
 			// -s ASSERTIONS=2 is very slow


### PR DESCRIPTION
The `-emit-llvm` emscripten parameters makes a small app build time go from 105s to 92s.