### PR TITLE
fix: Disable metadata updates by default

### DIFF
--- a/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.props
+++ b/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.props
@@ -1,5 +1,5 @@
 <Project>
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(WasmShellEnableMetadataUpdates)'=='true'">
     <UseMonoRuntime>true</UseMonoRuntime>
 
     <!--


### PR DESCRIPTION
Setting the `RuntimeIdentifier` from a nuget package causes issues during the local publication process.