### PR TITLE
fix(net6): Ensure wwwroot folder is included in the dist output

### DIFF
--- a/src/Uno.Wasm.Bootstrap-netcore-only.slnf
+++ b/src/Uno.Wasm.Bootstrap-netcore-only.slnf
@@ -13,6 +13,7 @@
       "Uno.Wasm.Node.Sample\\Uno.Wasm.Node.Sample.csproj",
       "Uno.Wasm.SampleNet5.Aot\\Uno.Wasm.SampleNet5.Aot.csproj",
       "Uno.Wasm.SampleNet5\\Uno.Wasm.SampleNet5.csproj",
+      "Uno.Wasm.SampleNet6\\Uno.Wasm.SampleNet6.csproj",
       "Uno.Wasm.Static Linking\\Uno.Wasm.StaticLinking.csproj",
       "Uno.Wasm.StaticLinking.Aot.Net5\\Uno.Wasm.StaticLinking.Aot.Net5.csproj",
       "Uno.Wasm.StaticLinking.Interpreter\\Uno.Wasm.StaticLinking.Interpreter.csproj",

--- a/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
+++ b/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
@@ -217,7 +217,7 @@
         EmccLinkOptimization="$(WasmShellEmccLinkOptimization)"
         EmccLinkOptimizationLevel="$(WasmShellEmccLinkOptimizationLevel)"
         NinjaAdditionalParameters="$(WasmShellNinjaAdditionalParameters)"
-        Assets="@(Content)"
+        Assets="@(Content);@(StaticWebAsset)"
         ContentExtensionsToExclude="$(WasmShellContentExtensionsToExclude)"
         ReferencePath="@(_UnoWasmBootstrapAssembliesForReferenceCopyLocalPaths)"
         RuntimeHostConfigurationOption="@(RuntimeHostConfigurationOption)"

--- a/src/Uno.Wasm.Sample/sample.common.props
+++ b/src/Uno.Wasm.Sample/sample.common.props
@@ -30,6 +30,7 @@
 
 	<Error Condition="!exists('$(WasmShellOutputPackagePath)\AdditionalContent\%(_AdditionalFile1.Identity)')" Text="%(_AdditionalFile1.Identity) does not exist in $(WasmShellOutputPackagePath)" />
 	<Error Condition="exists('$(WasmShellOutputPackagePath)\AdditionalContent\SomeContent04.txt')" Text="AdditionalContent/SomeContent04.tx should not exist in $(WasmShellOutputPackagePath)" />
+	<Error Condition="!exists('$(WasmShellOutputPackagePath)\..\web.config')" Text="web.config should exist in $(WasmShellOutputPackagePath)\.." />
 
 	<Error Condition="exists('$(WasmShellOutputDistPath)\AdditionalContent\%(_AdditionalFile1.Identity)')" Text="%(_AdditionalFile1.Identity) should not exist in $(WasmShellOutputDistPath)" />
 	<Error Condition="!exists('$(WasmShellOutputDistPath)\AdditionalContent\SomeContent03.txt')" Text="AdditionalContent/SomeContent03.txt does not exist in $(WasmShellOutputDistPath)" />


### PR DESCRIPTION
net6.0 removes content from the `Content` item group, and moves them to `StaticWebAsset`, which is now added in the Asset parameter of ShellTask.