### PR TITLE
fix: Update runtime to allow for debugger host to run without net5 installed

### DIFF
--- a/src/Uno.Wasm.Bootstrap/Constants.cs
+++ b/src/Uno.Wasm.Bootstrap/Constants.cs
@@ -7,7 +7,7 @@ namespace Uno.Wasm.Bootstrap
 	internal class Constants
 	{
 		public const string DefaultDotnetRuntimeSdkUrl = "https://unowasmbootstrap.azureedge.net/runtime/"
-			+ "dotnet-runtime-wasm-linux-4ffd776-53ca85fb900-1814093915-Release.zip";
+			+ "dotnet-runtime-wasm-linux-bd114dd-53ca85fb900-1877706367-Release.zip";
 
 		/// <summary>
 		/// Min version of the emscripten SDK. Must be aligned with dotnet/runtime SDK build in <see cref="NetCoreWasmSDKUri"/>.


### PR DESCRIPTION
Related to https://github.com/unoplatform/uno/discussions/7999