### PR TITLE
AOT Profiler fixes

### DIFF
--- a/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
+++ b/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
@@ -81,6 +81,7 @@
   <Target Name="WasmBootstrapAdjustFrameworkReference" BeforeTargets="ProcessFrameworkReferences">
     <PropertyGroup>
       <_WasmShellIsNetCore Condition="'$(TargetFrameworkIdentifier)'=='.NETCoreApp' and '$(TargetFrameworkVersion.Substring(1))'&gt;='5.0'">true</_WasmShellIsNetCore>
+      <WasmShellIncludeWindowsCompatibility Condition="'$(WasmShellIncludeWindowsCompatibility)'==''">true</WasmShellIncludeWindowsCompatibility>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(_WasmShellIsNetCore)'=='true'">
@@ -90,7 +91,7 @@
       items added explicitly by the building project.
       -->
       <FrameworkReference Remove="Microsoft.AspNetCore.App" IsImplicitlyDefined="true" />
-      <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.0" />
+      <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.0" Condition="$(WasmShellIncludeWindowsCompatibility)" />
     </ItemGroup>
   </Target>
 

--- a/src/Uno.Wasm.Bootstrap/ts/Uno/WebAssembly/AotProfilerSupport.ts
+++ b/src/Uno.Wasm.Bootstrap/ts/Uno/WebAssembly/AotProfilerSupport.ts
@@ -48,7 +48,7 @@
 
 			// Export the file
 			var a = window.document.createElement('a');
-			var blob = new Blob([this._context.INTERNAL.aot_profile_data]);
+			var blob = new Blob([(<any>this._context.Module).aot_profile_data]);
 			a.href = window.URL.createObjectURL(blob);
 			a.download = "aot.profile";
 

--- a/src/Uno.Wasm.Bootstrap/ts/types/dotnet/index.d.ts
+++ b/src/Uno.Wasm.Bootstrap/ts/types/dotnet/index.d.ts
@@ -56,6 +56,14 @@ declare interface EmscriptenModule {
 	instantiateWasm: (imports: any, successCallback: Function) => any;
 	ENVIRONMENT_IS_NODE: boolean;
 	ENVIRONMENT_IS_WEB: boolean;
+
+	/**
+	 * BEGIN UNO CUSTOM
+	 */
+	aot_profile_data: any;
+	/**
+	 * END UNO CUSTOM
+	 */
 }
 declare type TypedArray = Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array;
 


### PR DESCRIPTION
- fixes the generation of the AOT profile under net7
- Add the ability to disable the automatic inclusion of Microsoft.Windows.Compatibility (https://github.com/unoplatform/Uno.Wasm.Bootstrap/issues/423)