### PR TITLE
fix: Restore log profiler feature

### DIFF
--- a/src/Uno.Wasm.Bootstrap/Constants.cs
+++ b/src/Uno.Wasm.Bootstrap/Constants.cs
@@ -7,7 +7,7 @@ namespace Uno.Wasm.Bootstrap
 	internal class Constants
 	{
 		public const string DefaultDotnetRuntimeSdkUrl = "https://unowasmbootstrap.azureedge.net/runtime/"
-			+ "dotnet-runtime-wasm-linux-e0c5b0e-ca82565a603-3091924971-Release.zip";
+			+ "dotnet-runtime-wasm-linux-b24f5ef-43a11661ae9-3109520748-Release.zip";
 
 		/// <summary>
 		/// Min version of the emscripten SDK. Must be aligned with dotnet/runtime SDK build in <see cref="NetCoreWasmSDKUri"/>.

--- a/src/Uno.Wasm.Bootstrap/ShellTask.cs
+++ b/src/Uno.Wasm.Bootstrap/ShellTask.cs
@@ -135,7 +135,7 @@ namespace Uno.Wasm.Bootstrap
 
 		public bool EnableLogProfiler { get; set; }
 
-		public string LogProfilerOptions { get; set; } = "log:alloc,output=output.mlpd,zip";
+		public string LogProfilerOptions { get; set; } = "log:alloc,output=output.mlpd";
 
 		public string AssembliesFileExtension { get; set; } = "clr";
 

--- a/src/Uno.Wasm.Bootstrap/ts/Uno/WebAssembly/Bootstrapper.ts
+++ b/src/Uno.Wasm.Bootstrap/ts/Uno/WebAssembly/Bootstrapper.ts
@@ -24,7 +24,7 @@ namespace Uno.WebAssembly.Bootstrap {
 		private _runMain: (mainAssemblyName: string, args: string[]) => Promise<number>;
 
 		private _webAppBasePath: string;
-        private _appBase: string;
+		private _appBase: string;
 
 		private body: HTMLElement;
 		private loader: HTMLElement;
@@ -34,10 +34,10 @@ namespace Uno.WebAssembly.Bootstrap {
 		private _currentBrowserIsChrome: boolean;
 		private _hasReferencedPdbs: boolean;
 
-        static ENVIRONMENT_IS_WEB: boolean;
-        static ENVIRONMENT_IS_WORKER: boolean;
-        static ENVIRONMENT_IS_NODE: boolean;
-        static ENVIRONMENT_IS_SHELL: boolean;
+		static ENVIRONMENT_IS_WEB: boolean;
+		static ENVIRONMENT_IS_WORKER: boolean;
+		static ENVIRONMENT_IS_NODE: boolean;
+		static ENVIRONMENT_IS_SHELL: boolean;
 
 		constructor(unoConfig: Uno.WebAssembly.Bootstrap.UnoConfig) {
 			this._unoConfig = unoConfig;
@@ -136,21 +136,21 @@ namespace Uno.WebAssembly.Bootstrap {
 			this.setupHotReload();
 		}
 
-        private setupHotReload() {
-            if (this._context.Module.ENVIRONMENT_IS_WEB && this.hasDebuggingEnabled()) {
-                this._hotReloadSupport = new HotReloadSupport(this._context);
-            }
-        }
+		private setupHotReload() {
+			if (this._context.Module.ENVIRONMENT_IS_WEB && this.hasDebuggingEnabled()) {
+				this._hotReloadSupport = new HotReloadSupport(this._context);
+			}
+		}
 
 		private setupEmscriptenPreRun() {
-            if (!this._context.Module.preRun) {
-                this._context.Module.preRun = [];
-            }
-            else if (typeof this._context.Module.preInit === "function") {
-                this._context.Module.preRun = [];
-            }
-            (<any>this._context.Module.preRun).push(() => this.wasmRuntimePreRun());
-        }
+			if (!this._context.Module.preRun) {
+				this._context.Module.preRun = [];
+			}
+			else if (typeof this._context.Module.preRun === "function") {
+				this._context.Module.preRun = [];
+			}
+			(<any>this._context.Module.preRun).push(() => this.wasmRuntimePreRun());
+		}
 
 		/**
 		 * Setup the global require.js library
@@ -158,11 +158,11 @@ namespace Uno.WebAssembly.Bootstrap {
 		 * This setup is needed as .NET 7 sets up its own require function
 		 * if none is present, and the bootstrapper uses a global require.js.
 		 * */
-        private setupRequire() {
-            const anyModule = <any>this._context.Module;
-            anyModule.imports = anyModule.imports || {};
-            anyModule.imports.require = (<any>globalThis).require;
-        }
+		private setupRequire() {
+			const anyModule = <any>this._context.Module;
+			anyModule.imports = anyModule.imports || {};
+			anyModule.imports.require = (<any>globalThis).require;
+		}
 
 		private wasmRuntimePreRun() {
 
@@ -229,6 +229,12 @@ namespace Uno.WebAssembly.Bootstrap {
 				};
 			}
 
+			var logProfilerConfig = this._unoConfig.environmentVariables["UNO_BOOTSTRAP_LOG_PROFILER_OPTIONS"];
+			if (logProfilerConfig) {
+				this._monoConfig.logProfilerOptions = <LogProfilerOptions>{
+					configuration: logProfilerConfig
+				};
+			}
 		}
 
 		private runtimeAbort() {

--- a/src/Uno.Wasm.Bootstrap/ts/Uno/WebAssembly/LogProfilerSupport.ts
+++ b/src/Uno.Wasm.Bootstrap/ts/Uno/WebAssembly/LogProfilerSupport.ts
@@ -18,13 +18,10 @@
 		public static initializeLogProfiler(unoConfig: Uno.WebAssembly.Bootstrap.UnoConfig): boolean {
 			const options = unoConfig.environmentVariables["UNO_BOOTSTRAP_LOG_PROFILER_OPTIONS"];
 			if (options) {
-				Module.ccall('mono_wasm_load_profiler_log', null, ['string'], [options]);
-
 				this._logProfilerEnabled = true;
-
 				return true;
 			}
-
+				
 			return false;
 		}
 
@@ -97,6 +94,7 @@
 				return FS.readFile(profileFilePath);
 			}
 			else {
+				console.debug(`Unable to fetch the profile file ${profileFilePath} as it is empty`);
 				return null;
 			}
 		}

--- a/src/Uno.Wasm.Bootstrap/ts/types/dotnet/index.d.ts
+++ b/src/Uno.Wasm.Bootstrap/ts/types/dotnet/index.d.ts
@@ -143,6 +143,7 @@ declare type MonoConfig = {
 	 */
 	aotProfilerOptions?: AOTProfilerOptions;
 	coverageProfilerOptions?: CoverageProfilerOptions;
+	logProfilerOptions?: LogProfilerOptions;
 	/**
 	 * END UNO SPECIFIC
 	 */

--- a/src/Uno.Wasm.Bootstrap/ts/types/dotnet/mono.d.ts
+++ b/src/Uno.Wasm.Bootstrap/ts/types/dotnet/mono.d.ts
@@ -77,3 +77,6 @@ declare type CoverageProfilerOptions = {
 	writeAt?: string;
 	sendTo?: string;
 };
+declare type LogProfilerOptions = {
+	configuration?: string, //  log profiler options string"
+}

--- a/src/Uno.Wasm.Sample/WasmScripts/test.js
+++ b/src/Uno.Wasm.Sample/WasmScripts/test.js
@@ -4,10 +4,15 @@
     parent.append(txt);
 });
 
-// Needs to be
+// Needs to be initialized early
 async function initializeExports() {
     if (Module.getAssemblyExports !== undefined) {
-        globalThis.samplesNetExports = await Module.getAssemblyExports("Uno.Wasm.StaticLinking");
+        try {
+            globalThis.samplesNetExports = await Module.getAssemblyExports("Uno.Wasm.SampleNet");
+        }
+        catch (e) {
+            log.error(e);
+        }
     }
 }
 
@@ -15,11 +20,11 @@ initializeExports();
 
 function testCallback() {
     try {
-        if (Module.getAssemblyExports !== undefined) {
-            return samplesNetExports.Uno.Wasm.Sample.Exports.MyExportedMethod();
+        if (Module.getAssemblyExports !== undefined && samplesNetExports.hasOwnProperty('Uno')) {
+            return samplesNetExports.Uno.Wasm.SampleNet.Exports.MyExportedMethod1();
         }
         else {
-            return Module.mono_bind_static_method("[Uno.Wasm.Sample] Uno.Wasm.Sample.Program:MyExportedMethod")();
+            return Module.mono_bind_static_method("[Uno.Wasm.SampleNet] Uno.Wasm.Sample.Exports:MyExportedMethod2")();
         }
     }
     catch (e) {

--- a/src/Uno.Wasm.SampleNet6.LogProfiler/LinkerConfig.xml
+++ b/src/Uno.Wasm.SampleNet6.LogProfiler/LinkerConfig.xml
@@ -1,4 +1,4 @@
 ﻿<linker>
-	<assembly fullname="Uno.Wasm.SampleNet5"/>
+	<assembly fullname="Uno.Wasm.SampleNet"/>
 	<assembly fullname="System.Private.CoreLib"/>
 </linker>

--- a/src/Uno.Wasm.SampleNet6.LogProfiler/Uno.Wasm.SampleNet6.LogProfiler.csproj
+++ b/src/Uno.Wasm.SampleNet6.LogProfiler/Uno.Wasm.SampleNet6.LogProfiler.csproj
@@ -18,7 +18,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Identity.Client" Version="4.14.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-		<PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
+		<PackageReference Include="System.Collections.Immutable" Version="1.4.0" /> 
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
 	</ItemGroup>
 


### PR DESCRIPTION
gzip of the mlpd file is disabled as the latest builds (VS 17.4) of the xamarin profiler do not seem to support it properly.