### PR TITLE
Fixed Typo in Section Title

### DIFF
--- a/doc/using-the-bootstrapper.md
+++ b/doc/using-the-bootstrapper.md
@@ -82,7 +82,7 @@ The SDKs are installed under `Path.GetTempPath()` by default, you may change thi
 
 For example, on Windows, setting `WasmShellMonoTempFolder` to `C:\MonoWasmSDKs`, the `mono-wasm-e351637985e` sdk would be installed under `C:\MonoWasmSDKs\mono-wasm-e351637985e`
 
-### Bootstrapper versioms and .NET runtimes
+### Bootstrapper versions and .NET runtimes
 Each major version of the bootstrapper targets a different version of the .NET Runtime.
 
 - 2.x: Mono runtime (https://github.com/mono/mono)


### PR DESCRIPTION
The section title for "Bootstrapper versions and .NET runtimes" had a "m" where the "n" should have been in the word "versions".