### PR TITLE
fix: Fixed service worker install error

### DIFF
--- a/src/Uno.Wasm.Bootstrap/WasmScripts/service-worker.js
+++ b/src/Uno.Wasm.Bootstrap/WasmScripts/service-worker.js
@@ -1,21 +1,14 @@
-﻿console.debug("[ServiceWorker] Initializing");
+﻿import { config } from "$(REMOTE_WEBAPP_PATH)$(REMOTE_BASE_PATH)/uno-config.js";
 
-let config = {};
+console.debug("[ServiceWorker] Initializing");
 
 self.addEventListener('install', function (e) {
     console.debug('[ServiceWorker] Installing offline worker');
     e.waitUntil(
-        fetch("$(REMOTE_WEBAPP_PATH)$(REMOTE_BASE_PATH)uno-config.js")
-            .then(r => r.text()
-                .then(configStr => {
-                    eval(configStr);
-                    caches.open('$(CACHE_KEY)').then(function (cache) {
-                        console.debug('[ServiceWorker] Caching app binaries and content');
-                        return cache.addAll(config.offline_files);
-                    });
-                }
-                )
-            )
+        caches.open('$(CACHE_KEY)').then(function (cache) {
+            console.debug('[ServiceWorker] Caching app binaries and content');
+            return cache.addAll(config.offline_files);
+        })
     );
 });
 

--- a/src/Uno.Wasm.Bootstrap/ts/Uno/WebAssembly/Bootstrapper.ts
+++ b/src/Uno.Wasm.Bootstrap/ts/Uno/WebAssembly/Bootstrapper.ts
@@ -681,7 +681,8 @@ namespace Uno.WebAssembly.Bootstrap {
 						navigator.serviceWorker
 							.register(
 								`${_webAppBasePath}service-worker.js`, {
-								scope: _webAppBasePath
+								scope: _webAppBasePath,
+								type: 'module'
 							})
 							.then(function () {
 								console.debug('Service Worker Registered');


### PR DESCRIPTION
Instead of `eval`ing the `uno-config.js` file, `service-worker.js` is now loaded as a module to allow `import`ing the `uno-config.js` module.

Should fix #624. 