### PR TITLE
feat!(?): Do not remove loader unless explicitly required

### DIFF
--- a/src/Uno.Wasm.Bootstrap/WasmCSS/uno-bootstrap.css
+++ b/src/Uno.Wasm.Bootstrap/WasmCSS/uno-bootstrap.css
@@ -1,12 +1,10 @@
-﻿.uno-window-backplate {
-    position: fixed;
-    width: 100%;
-    height: 100%;
+﻿.uno-loader {
     background-color: var(--light-theme-bg-color, #F3F3F3);
+    z-index: 5000;
 }
 
 @media (prefers-color-scheme: dark) {
-    .uno-window-backplate {
+    .uno-loader {
         background-color: var(--dark-theme-bg-color, #202020);
     }
 }
@@ -148,16 +146,16 @@
         color: DarkRed;
     }
 
-@keyframes pulse {
-    0% {
-        transform: scale(0.85);
-    }
+    @keyframes pulse {
+        0% {
+            transform: scale(0.85);
+        }
 
-    50% {
-        transform: scale(1.15);
-    }
+        50% {
+            transform: scale(1.15);
+        }
 
-    100% {
-        transform: scale(0.85);
+        100% {
+            transform: scale(0.85);
+        }
     }
-}


### PR DESCRIPTION
This change undoes the Persistent background changes made in https://github.com/unoplatform/Uno.Wasm.Bootstrap/pull/692, because it turns out they are not the crux of the problem.

When the WASM app loads, after the bootstrapper is done, it currently removes the loader (`.uno-loader`) and then the app itself is initialized. This takes a few hundreds of milliseconds after which Uno itself creates its own "loader" (`#uno-loading`). Unfortunately, those milliseconds are a problem - as they mean that a plain white background will flash there which is very jarring.

This PR changes the default behavior of the bootstrapper to keep the `.uno-loader` in place even after initialization is done until some child is actually added to `uno-body`. This means that it will stay displayed while the actual app is loading, and when it indeed adds its `#uno-loading` element it should remove bootstrapper's `.uno-loader` afterwards.

**Question for @jeromelaban - is this actually a breaking change? Are there any non-Uno apps which would not add content to `.uno-body` - resulting in the loader not disappearing?**