### PR TITLE
feat: Allow Uno app to persist the loader

### DIFF
--- a/src/Uno.Wasm.Bootstrap/ts/Uno/WebAssembly/Bootstrapper.ts
+++ b/src/Uno.Wasm.Bootstrap/ts/Uno/WebAssembly/Bootstrapper.ts
@@ -326,13 +326,21 @@ namespace Uno.WebAssembly.Bootstrap {
 				if (this.loader.parentElement == this.body) {
 
 					this.bodyObserver = new MutationObserver(() => {
-						this.loader.parentNode.removeChild(this.loader);
+						if (!this.loader.classList.contains("keep-loader")){
+							// This version of Uno Platform cannot remove
+							// bootstrapper's loader, so we must do it.
+							this.loader.parentNode.removeChild(this.loader);
+						}
 						this.bodyObserver.disconnect();
 						this.bodyObserver = null;
 					});
 
 					this.bodyObserver.observe(this.body, { childList: true });
 				}
+
+				// Used by Uno Platform to detect this bootstrapper version
+				// can keep the loader displayed when requested
+				this.loader.classList.add("persistent-loader");
 			}
 
 			const configLoader = () => {

--- a/src/Uno.Wasm.Bootstrap/ts/Uno/WebAssembly/Bootstrapper.ts
+++ b/src/Uno.Wasm.Bootstrap/ts/Uno/WebAssembly/Bootstrapper.ts
@@ -326,7 +326,7 @@ namespace Uno.WebAssembly.Bootstrap {
 				if (this.loader.parentElement == this.body) {
 
 					this.bodyObserver = new MutationObserver(() => {
-						if (!this.loader.classList.contains("keep-loader")){
+						if (!this.loader.classList.contains("uno-keep-loader")){
 							// This version of Uno Platform cannot remove
 							// bootstrapper's loader, so we must do it.
 							this.loader.parentNode.removeChild(this.loader);
@@ -340,7 +340,7 @@ namespace Uno.WebAssembly.Bootstrap {
 
 				// Used by Uno Platform to detect this bootstrapper version
 				// can keep the loader displayed when requested
-				this.loader.classList.add("persistent-loader");
+				this.loader.classList.add("uno-persistent-loader");
 			}
 
 			const configLoader = () => {


### PR DESCRIPTION
Currently there are two splash screens - one in Bootstrapper and one in Uno. This change will allow the Uno app to indicate the bootstrapper should avoid removing its splash screen, and let this concern for the Uno app to handle. This will ensure there will be absolutely no flashing of blank page before the app loads.

The change is done in a way that there will be nothing breaking - e.g. new bootstrapper will still work with older versions of Uno and new Uno versions will still work with older versions of bootstrapper.

This commit and PR https://github.com/unoplatform/uno/pull/11864 in Uno will add support for this feature - https://github.com/unoplatform/uno/pull/11864/commits/39d44ee3fa99cccb00e73ea3df354e1e81c0e989