### PR TITLE
fix(tuner): Don't copy the tuner binaries in the runtime tools folder

### DIFF
--- a/src/Uno.Wasm.Bootstrap/ShellTask.cs
+++ b/src/Uno.Wasm.Bootstrap/ShellTask.cs
@@ -207,6 +207,8 @@ namespace Uno.Wasm.Bootstrap
 
 		public string? CustomLinkerPath { get; set; }
 
+		public string? WasmTunerBinPath { get; set; }
+
 		public string? PWAManifestFile { get; set; }
 
 		public bool EnableLongPathSupport { get; set; } = true;
@@ -895,6 +897,7 @@ namespace Uno.Wasm.Bootstrap
 				packagerParams.Add(referencePathsParameter);
 				packagerParams.Add(GenerateAOTProfile ? "--profile=aot" : "");
 				packagerParams.Add(EnableLogProfiler ? "--profile=log" : "");
+				packagerParams.Add(!string.IsNullOrEmpty(WasmTunerBinPath) ? $"\"--wasm-tuner-path={AlignPath(Path.GetFullPath(WasmTunerBinPath))}\"" : "");
 				packagerParams.Add($"\"--linker-optimization-level={GetEmccLinkerOptimizationLevel()}\"");
 				packagerParams.Add($"\"{AlignPath(Path.GetFullPath(Assembly))}\"");
 

--- a/src/Uno.Wasm.Bootstrap/Uno.Wasm.Bootstrap.csproj
+++ b/src/Uno.Wasm.Bootstrap/Uno.Wasm.Bootstrap.csproj
@@ -218,6 +218,7 @@
 		<ItemGroup>
 			<_PackagerNet5Files Include="../Uno.Wasm.Packager/bin/$(Configuration)/net5.0/packager.*" />
 			<_TunerNet5Files Include="../Uno.Wasm.Tuner/bin/$(Configuration)/net5.0/wasm-tuner.*" />
+			<_TunerNet5Files Include="../Uno.Wasm.Tuner/bin/$(Configuration)/net5.0/Mono.Cecil.*" />
 			<_TunerNet5Files Include="../Uno.Wasm.Tuner/bin/$(Configuration)/net5.0/System.Json.dll" />
 			<_TunerNet5Files Include="../Uno.Wasm.Tuner/bin/$(Configuration)/net5.0/System.Reflection.MetadataLoadContext.dll" />
 		</ItemGroup>

--- a/src/Uno.Wasm.Bootstrap/UnoInstallSDKTask.cs
+++ b/src/Uno.Wasm.Bootstrap/UnoInstallSDKTask.cs
@@ -42,9 +42,6 @@ namespace Uno.Wasm.Bootstrap
 		public string PackagerOverrideFolderPath { get; set; } = "";
 
 		[Required]
-		public string WasmTunerOverrideFolderPath { get; set; } = "";
-
-		[Required]
 		public string CilStripOverrideFolderPath { get; set; } = "";
 
 		[Required]
@@ -75,8 +72,6 @@ namespace Uno.Wasm.Bootstrap
 
 		[Output]
 		public string? PackagerBinPath { get; set; }
-		[Output]
-		public string? WasmTunerBinPath { get; set; }
 
 		[Output]
 		public string? PackagerProjectFile { get; private set; }
@@ -136,7 +131,6 @@ namespace Uno.Wasm.Bootstrap
 			{
 				void WriteTools()
 				{
-					WriteWasmTuner();
 					WriteCilStrip();
 				}
 
@@ -264,22 +258,6 @@ namespace Uno.Wasm.Bootstrap
 			if (IsOSUnixLike)
 			{
 				Process.Start("chmod", $"-R +x \"{SdkPath}\"");
-			}
-		}
-
-		private void WriteWasmTuner()
-		{
-			if (!string.IsNullOrEmpty(WasmTunerOverrideFolderPath))
-			{
-				var basePath = Path.Combine(SdkPath, "tools");
-				Directory.CreateDirectory(basePath);
-
-				foreach (var file in Directory.EnumerateFiles(WasmTunerOverrideFolderPath))
-				{
-					var destFileName = Path.Combine(basePath, Path.GetFileName(file));
-					Log.LogMessage($"Copy wasm-tuner {file} to {destFileName}");
-					File.Copy(file, destFileName, true);
-				}
 			}
 		}
 

--- a/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
+++ b/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
@@ -268,6 +268,7 @@
 			TargetFrameworkVersion="$(TargetFrameworkVersion)"
 			UseFileIntegrity="$(WashShellUseFileIntegrity)"
 			WasmShellMode="$(WasmShellMode)"
+			WasmTunerBinPath="$(MSBuildThisFileDirectory)/wasm-tuner/net5.0/wasm-tuner.dll"
 			WebAppBasePath="$(WasmShellWebAppBasePath)"
         >
 			<Output TaskParameter="OutputPackagePath" PropertyName="WasmShellOutputPackagePath" />

--- a/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
+++ b/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
@@ -197,7 +197,6 @@
 			TargetFramework="$(TargetFramework)"
 			TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
 			TargetFrameworkVersion="$(TargetFrameworkVersion)"
-			WasmTunerOverrideFolderPath="$(MSBuildThisFileDirectory)/wasm-tuner/$(_WasmShellToolSuffix)"
         >
 			<Output TaskParameter="SdkPath" PropertyName="_UnoMonoSdkPath" />
 			<Output TaskParameter="PackagerBinPath" PropertyName="_UnoMonoPackagerBinPath" />

--- a/src/Uno.Wasm.Packager/packager.cs
+++ b/src/Uno.Wasm.Packager/packager.cs
@@ -508,6 +508,7 @@ class Driver {
 		string extra_emccflags = "";
 		string extra_linkerflags = "";
 		string linker_optimization_level = "";
+		string wasm_tuner_path = "";
 		var linker_args = new List<string>();
 
 		var opts = new WasmOptions () {
@@ -564,6 +565,7 @@ class Driver {
 				{ "illinker-path=", s => illinker_path = s },
 				{ "extra-linkerflags=", s => extra_linkerflags = s },
 				{ "linker-optimization-level=", s => linker_optimization_level = s },
+				{ "wasm-tuner-path=", s => wasm_tuner_path = s },
 				{ "help", s => print_usage = true },
 			};
 
@@ -1410,7 +1412,11 @@ class Driver {
 
 		var linkerSearchPaths = root_search_paths.Concat(bcl_prefixes).Distinct().Select(p => $"-d \"{p}\" ");
 
-		var tunerCommand = is_netcore ? $"dotnet $tools_dir{Path.DirectorySeparatorChar}wasm-tuner.dll" : "mono $tools_dir/wasm-tuner.exe";
+		var tunerCommand = $"dotnet " +
+			(string.IsNullOrEmpty(wasm_tuner_path)
+				? $"$tools_dir{Path.DirectorySeparatorChar}wasm-tuner.dll"
+				: wasm_tuner_path);
+
 		var exitCommand = is_windows ? failOnError : "|| exit 1";
 
 		linker_args.Add($"-out ./linker-out --deterministic --disable-opt unreachablebodies");


### PR DESCRIPTION
This avoids transient issues when upgrading the bootstrapper on the same runtime folder, while having tuner changes.

Fixes https://github.com/unoplatform/Uno.Wasm.Bootstrap/issues/717