### PR TITLE
fix: Remove readonly attribute for output path deletion

### DIFF
--- a/.vsts-ci-windows-tests.yml
+++ b/.vsts-ci-windows-tests.yml
@@ -30,6 +30,10 @@ jobs:
       includePreviewVersions: true
 
   - pwsh: |
+        attrib +r "$(build.sourcesdirectory)/src" /s /d
+    displayName: Set all repo files as readonly
+
+  - pwsh: |
       cd $(build.sourcesdirectory)/src/Uno.Wasm.Bootstrap
       dotnet msbuild /r /p:Configuration=Release /p:DISABLE_CLIHOST_NET6=true
     displayName: Build bootstrap

--- a/src/Uno.Wasm.Bootstrap/Extensions/PathHelper.cs
+++ b/src/Uno.Wasm.Bootstrap/Extensions/PathHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 namespace Uno.Wasm.Bootstrap.Extensions;
 
@@ -13,4 +14,31 @@ internal class PathHelper
 	public static string FixupPath(string path)
 		=> path.Replace(OtherDirectorySeparatorChar, Path.DirectorySeparatorChar);
 
+	/// <summary>
+	/// Recursively deletes a path, including files with the readonly attribute
+	/// </summary>
+	public static void DeleteDirectory(string path)
+	{
+		if (Directory.Exists(path))
+		{
+			if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+			{
+				// Some files may have been copied over from the source
+				// files with a readonly attribute, let's remove it before deleting
+
+				foreach (var file in Directory.GetFiles(path, "*", SearchOption.AllDirectories))
+				{
+					var attributes = File.GetAttributes(file);
+
+					if ((attributes & FileAttributes.ReadOnly) != 0)
+					{
+						File.SetAttributes(file, attributes & ~FileAttributes.ReadOnly);
+					}
+				}
+			}
+
+			// Delete all files and folders recursively
+			Directory.Delete(path, true);
+		}
+	}
 }

--- a/src/Uno.Wasm.Bootstrap/RemoveDirTask.cs
+++ b/src/Uno.Wasm.Bootstrap/RemoveDirTask.cs
@@ -1,0 +1,43 @@
+﻿// ******************************************************************
+// Copyright � 2015-2022 Uno Platform inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ******************************************************************
+// 
+// This file is based on the work from https://github.com/praeclarum/Ooui
+// 
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Uno.Wasm.Bootstrap.Extensions;
+
+namespace Uno.Wasm.Bootstrap;
+
+public class RemoveDirTask_v0 : Microsoft.Build.Utilities.Task
+{
+	[Required]
+	public string Path { get; private set; } = "";
+
+	public override bool Execute()
+	{
+		var fixedPath = PathHelper.FixupPath(Path);
+		PathHelper.DeleteDirectory(fixedPath);
+
+		return true;
+	}
+}

--- a/src/Uno.Wasm.Bootstrap/ShellTask.cs
+++ b/src/Uno.Wasm.Bootstrap/ShellTask.cs
@@ -771,7 +771,7 @@ namespace Uno.Wasm.Bootstrap
 
 			if (Directory.Exists(workAotPath))
 			{
-				Directory.Delete(workAotPath, true);
+				DirectoryDelete(workAotPath);
 			}
 
 			DirectoryCreateDirectory(workAotPath);
@@ -988,7 +988,7 @@ namespace Uno.Wasm.Bootstrap
 
 					if (Directory.Exists(linkerInput))
 					{
-						Directory.Delete(linkerInput, true);
+						DirectoryDelete(linkerInput);
 					}
 
 					Directory.Move(_managedPath, linkerInput);
@@ -1579,7 +1579,7 @@ namespace Uno.Wasm.Bootstrap
 
 			if (Directory.Exists(_distPath))
 			{
-				Directory.Delete(_distPath, true);
+				DirectoryDelete(_distPath);
 			}
 
 			try
@@ -1605,6 +1605,9 @@ namespace Uno.Wasm.Bootstrap
 
 			TryObfuscateAssemblies(Path.Combine(_finalPackagePath, Path.GetFileName(_managedPath)));
 		}
+
+		private void DirectoryDelete(string path)
+			=> PathHelper.DeleteDirectory(path);
 
 		private static void MoveFileSafe(string source, string target)
 		{
@@ -1688,12 +1691,12 @@ namespace Uno.Wasm.Bootstrap
 
 			if (Directory.Exists(_workDistPath))
 			{
-				Directory.Delete(_workDistPath, true);
+				DirectoryDelete(_workDistPath);
 			}
 
 			if (Directory.Exists(_workDistRootPath))
 			{
-				Directory.Delete(_workDistRootPath, true);
+				DirectoryDelete(_workDistRootPath);
 			}
 
 			Log.LogMessage($"Creating managed path {_managedPath}");

--- a/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
+++ b/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
@@ -310,13 +310,7 @@
 			<WasmShellDistPath Condition="'$(WasmShellDistPath)'==''">$(OutputPath)/dist</WasmShellDistPath>
 		</PropertyGroup>
 
-		<ItemGroup>
-			<_DistFilesToDelete Include="$(OutputPath)dist\**" />
-			<_DistDirToDelete Include="$([System.IO.Directory]::GetDirectories(&quot;$(WasmShellDistPath)&quot;))" Condition="exists('$(WasmShellDistPath)')" />
-		</ItemGroup>
-
-		<Delete Files="@(_DistFilesToDelete)" />
-		<RemoveDir Directories="@(_DistDirToDelete)" />
+		<RemoveDirTask_v0 Path="$(WasmShellDistPath)" />
 	</Target>
 
 	<Target Name="_ValidateLegacyCLIPackage" BeforeTargets="CoreCompile">


### PR DESCRIPTION
Related to https://github.com/unoplatform/Uno.Wasm.Bootstrap/pull/814