### PR TITLE
fix: Don't define caps when the uno.sdk is present

### DIFF
--- a/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.props
+++ b/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.props
@@ -15,7 +15,7 @@
 		<WasmGenerateAppBundle>false</WasmGenerateAppBundle>
 	</PropertyGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition=" '$(UsingUnoSdk)' != 'true' ">
 		<ProjectCapability Include="WebAssembly" />
 		<ProjectCapability Include="SupportsHotReload" />
 


### PR DESCRIPTION
This allows for VS to avoid showing "reload project" as caps get defined when nuget packages are restored