### PR TITLE
[doc] Correct link and add info about existing `Linkerconfig.xml` on WASM

### DIFF
--- a/doc/linker-configuration.md
+++ b/doc/linker-configuration.md
@@ -20,7 +20,7 @@ The Bootstrapper searches for a file placed in an ItemGroup named `LinkerDescrip
 </linker>
 ```
 
-The documentation for this file [can be found here](https://github.com/mono/linker/blob/master/docs/data-formats.md#xml-examples).
+The documentation for this file [can be found here](https://github.com/dotnet/runtime/blob/9fca0c3dbd3874ed0245b1bdb10547d0ba769d66/docs/tools/illink/data-formats.md).
 
 ### Reference in project file
 

--- a/doc/linker-configuration.md
+++ b/doc/linker-configuration.md
@@ -58,5 +58,5 @@ If you need to enable any of those features, you can set the following in your c
 
 Setting `InvariantGlobalization` to true will remove all satellite assemblies from the final package. 
 
-### LinkerConfig.xml on WASM
-For WASM the Uno-App already contains a 'LinkerConfig.xml' in the folder `Platforms\WebAssembly\LinkerConfig.xml'.
+### LinkerConfig.xml on WebAssembly
+When using the Uno Platform [solution template](https://aka.platform.uno/app-wizard), a file named 'LinkerConfig.xml' is available in the folder `Platforms\WebAssembly\LinkerConfig.xml'.

--- a/doc/linker-configuration.md
+++ b/doc/linker-configuration.md
@@ -57,3 +57,6 @@ If you need to enable any of those features, you can set the following in your c
 ```
 
 Setting `InvariantGlobalization` to true will remove all satellite assemblies from the final package. 
+
+### LinkerConfig.xml on WASM
+For WASM the Uno-App already contains a 'LinkerConfig.xml' in the folder `Platforms\WebAssembly\LinkerConfig.xml'.


### PR DESCRIPTION
I found a dead link and I added some Info about the already existing `LinkerConfig.xml` in WASM-projects.