### PR TITLE
fix: pass same-origin credentials - fixes #875

### DIFF
--- a/src/Uno.Wasm.Bootstrap/ts/Uno/WebAssembly/Bootstrapper.ts
+++ b/src/Uno.Wasm.Bootstrap/ts/Uno/WebAssembly/Bootstrapper.ts
@@ -416,7 +416,7 @@ namespace Uno.WebAssembly.Bootstrap {
 		private getFetchInit(url: string): RequestInit {
 			const fileName = url.substring(url.lastIndexOf("/") + 1);
 
-			const init: RequestInit = { credentials: "omit" };
+			const init: RequestInit = { credentials: "same-origin" };
 
 			if (this._unoConfig.files_integrity.hasOwnProperty(fileName)) {
 				init.integrity = this._unoConfig.files_integrity[fileName];
@@ -462,10 +462,10 @@ namespace Uno.WebAssembly.Bootstrap {
 
 			if (!this.loader) {
 				// No active loader, simply use the fetch API directly...
-				return fetch(url, {credentials: "same-origin"}, this.getFetchInit(url));
+				return fetch(url, this.getFetchInit(url));
 			}
 
-			return fetch(url, {credentials: "same-origin"}, this.getFetchInit(url))
+			return fetch(url, this.getFetchInit(url))
 				.then(response => {
 					if (!response.ok) {
 						throw Error(`${response.status} ${response.statusText}`);

--- a/src/Uno.Wasm.Bootstrap/ts/Uno/WebAssembly/Bootstrapper.ts
+++ b/src/Uno.Wasm.Bootstrap/ts/Uno/WebAssembly/Bootstrapper.ts
@@ -462,10 +462,10 @@ namespace Uno.WebAssembly.Bootstrap {
 
 			if (!this.loader) {
 				// No active loader, simply use the fetch API directly...
-				return fetch(url, this.getFetchInit(url));
+				return fetch(url, {credentials: "same-origin"}, this.getFetchInit(url));
 			}
 
-			return fetch(url, this.getFetchInit(url))
+			return fetch(url, {credentials: "same-origin"}, this.getFetchInit(url))
 				.then(response => {
 					if (!response.ok) {
 						throw Error(`${response.status} ${response.statusText}`);
@@ -567,7 +567,7 @@ namespace Uno.WebAssembly.Bootstrap {
 					}
 				}
 
-				return fetch(asset);
+				return fetch(asset, {credentials: "same-origin"});
 			}
 		}
 


### PR DESCRIPTION
passing `{credentials: "same-origin"}` into `fetch()` calls made by `Bootstrapper.ts` (`uno-bootstrap.js`in eventual web publish) means that the Uno Platform Wasm App will work on web hosting where we are behind authentication, requiring access to an authentication cookie (such as Azure Static Web Apps 'Password Protection')

addresses, fixes #875