### PR TITLE
chore: Update DeepLinking in toc.yml

### DIFF
--- a/doc/toc.yml
+++ b/doc/toc.yml
@@ -28,7 +28,7 @@ items:
       href: features-splash-screen.md
     - name: Threading
       href: features-threading.md
-    - name: Deep linking
+    - name: Deep linking (routing)
       href: features-deep-linking.md
     - name: Pre-compression
       href: features-pre-compression.md


### PR DESCRIPTION
Adjusted the name of Deep linking in toc.yml to include the more common routing for web dev.