### PR TITLE
chore: log service worker init error

### DIFF
--- a/src/Uno.Wasm.Bootstrap/ts/Uno/WebAssembly/Bootstrapper.ts
+++ b/src/Uno.Wasm.Bootstrap/ts/Uno/WebAssembly/Bootstrapper.ts
@@ -530,7 +530,11 @@ namespace Uno.WebAssembly.Bootstrap {
 							})
 							.then(function () {
 								console.debug('Service Worker Registered');
-							});
+							})
+							.catch(function(error) {
+								console.error('Error while registering service worker', error);
+								throw error;
+                            });
 					}
 				}
 			}


### PR DESCRIPTION
On Firefox, the service-worker is failing to initialize. Adding this `catch` to log these cases.