### PR TITLE
fix: Ensure explicit dependency for manifest generation

### DIFF
--- a/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
+++ b/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
@@ -261,6 +261,7 @@
 	<PropertyGroup>
 		<UnoGenerateAssetsManifestDependsOn>
 			$(UnoGenerateAssetsManifestDependsOn);
+			GenerateUnoWasmAssets;
 		</UnoGenerateAssetsManifestDependsOn>
 	</PropertyGroup>
 


### PR DESCRIPTION
Fixes a msbuild task dependencies breaking change introduced in .NET SDK 9.0.102.