### PR TITLE
feat: Add support for WasmShellNativeFileReference

### DIFF
--- a/doc/features-module-linking.md
+++ b/doc/features-module-linking.md
@@ -6,7 +6,7 @@ uid: UnoWasmBootstrap.ModuleLinking
 
 ## Static Linking overview
 
-Statically linking Emscripten LLVM Bitcode (`.o` and `.a` files) files is supported to embeds `.o` or `.a` files with the rest of the WebAssembly modules. This allows for using p/invoke when resolving methods from the loaded native library.
+Statically linking Emscripten LLVM Bitcode (`.o` and `.a` files) files is supported to embed `.o` or `.a` files with the rest of the WebAssembly modules. This allows for using p/invoke when resolving methods from the loaded native library.
 
 Files of type `.o` or `.a` specified in the MSBuild `WasmShellNativeFileReference` item will be statically linked in the application:
 

--- a/doc/features-module-linking.md
+++ b/doc/features-module-linking.md
@@ -6,13 +6,25 @@ uid: UnoWasmBootstrap.ModuleLinking
 
 ## Static Linking overview
 
-Statically linking Emscripten LLVM Bitcode (`.o` and `.a` files) files to mono is supported on both Windows 10 and Linux. To build on Windows please refer to the AOT environment setup instructions.
+Statically linking Emscripten LLVM Bitcode (`.o` and `.a` files) files is supported to embeds `.o` or `.a` files with the rest of the WebAssembly modules. This allows for using p/invoke when resolving methods from the loaded native library.
 
-This linking type embeds the `.o` or `.a` files with the rest of the WebAssembly modules, and uses _normal_ webassembly function invocations that are faster than with dynamic linking.
+Files of type `.o` or `.a` specified in the MSBuild `WasmShellNativeFileReference` item will be statically linked in the application:
 
-Any `.o` or `.a` file placed as `content` in the built project will be statically linked to the currently running application.
+```xml
+<ItemGroup>
+    <WasmShellNativeFileReference Include="libMy.a" />
+</ItemGroup>
+```
 
-This allowing for p/invoke to be functional when resolving methods from the loaded module. If you have a `.o` or a `.a` file you don't want to be include in the linking, you may add the `UnoAotCompile="false"` metadata that way:
+`WasmShellNativeFileReference` also supports multi-version filtering specified below.
+
+The .NET SDK [`NativeFileReference`](https://learn.microsoft.com/en-us/aspnet/core/blazor/webassembly-native-dependencies) is also supported.
+
+### Support for Native Files as `Content`
+
+Specifying native files as `Content` is also supported in version 9.x of the bootstrapper but will be removed in the next version.
+
+When specified as Content, if you have a `.o` or a `.a` file you don't want to be include in the linking, you may add the `UnoAotCompile="false"` metadata that way:
 
 ```xml
 <ItemGroup>
@@ -20,8 +32,6 @@ This allowing for p/invoke to be functional when resolving methods from the load
     <Content Update="path\to\my\file.a" UnoAotCompile="False" />
 </ItemGroup>
 ```
-
-The .NET SDK [`NativeFileReference`](https://learn.microsoft.com/en-us/aspnet/core/blazor/webassembly-native-dependencies) is also supported.
 
 ## WebAssembly Exceptions support
 

--- a/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
+++ b/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
@@ -301,7 +301,7 @@
 		<GenerateUnoNativeAssetsTask_v0
 			AotProfile="$(WasmAotProfilePath)"
 			AOTProfileExcludedMethods="$(WasmShellAOTProfileExcludedMethods)"
-			Assets="@(ContentWithTargetPath);@(_UnoWasmCopyToOutputAssets)"
+			Assets="@(WasmShellNativeFileReference);@(ContentWithTargetPath);@(_UnoWasmCopyToOutputAssets)"
 			CurrentProjectPath="$(MSBuildProjectDirectory)"
 			EmscriptenVersion="$(_UnoEmscriptenVersion)"
 			EnableThreads="@(WasmEnableThreads)"

--- a/src/Uno.Wasm.StaticLinking.Shared/Common.props
+++ b/src/Uno.Wasm.StaticLinking.Shared/Common.props
@@ -1,7 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
 	<ItemGroup Condition="'$(UseAOT)'=='true' or '$(WasmShellGenerateAOTProfile)'=='true' or '$(WasmShellEnableLogProfiler)'=='true'">
-		<Content Include="$(MSBuildThisFileDirectory)native/**/*.a" />
+		<WasmShellNativeFileReference Include="$(MSBuildThisFileDirectory)native/**/*.a" Exclude="$(MSBuildThisFileDirectory)native/side.a/**" />
+
+		<!-- Legacy content inclusion -->
+		<Content Include="$(MSBuildThisFileDirectory)native/side.a/*.a" />
+
 		<WasmShellNativeCompile Include="$(MSBuildThisFileDirectory)test.cpp" />
 		<WasmShellNativeCompile Include="$(MSBuildThisFileDirectory)test2.cpp" />
 	</ItemGroup>

--- a/src/Uno.Wasm.StaticLinking.Shared/Common.props
+++ b/src/Uno.Wasm.StaticLinking.Shared/Common.props
@@ -4,7 +4,7 @@
 		<WasmShellNativeFileReference Include="$(MSBuildThisFileDirectory)native/**/*.a" Exclude="$(MSBuildThisFileDirectory)native/side.a/**" />
 
 		<!-- Legacy content inclusion -->
-		<Content Include="$(MSBuildThisFileDirectory)native/side.a/*.a" />
+		<Content Include="$(MSBuildThisFileDirectory)native/side.a/**/*.a" Visible="False" />
 
 		<WasmShellNativeCompile Include="$(MSBuildThisFileDirectory)test.cpp" />
 		<WasmShellNativeCompile Include="$(MSBuildThisFileDirectory)test2.cpp" />


### PR DESCRIPTION
This avoids the use of Content as the source, which may cause duplicates in recent builds in .NET automatic assets management.