### PR TITLE
fix: Adjust workaround for #973

### DIFF
--- a/src/Uno.Wasm.Bootstrap.Server/build/Uno.Wasm.Bootstrap.Server.targets
+++ b/src/Uno.Wasm.Bootstrap.Server/build/Uno.Wasm.Bootstrap.Server.targets
@@ -1,3 +1,14 @@
 ﻿<Project>
 
+	<!-- Workaround for https://github.com/unoplatform/Uno.Wasm.Bootstrap/issues/973 -->
+	<Target Name="_UnoAdjustResolveReferencedProjectsStaticWebAssetsConfiguration"
+			AfterTargets="ResolveReferencedProjectsStaticWebAssetsConfiguration"
+			Condition=" $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '9.0.300')) and '$(UnoDisableGetCurrentProjectBuildStaticWebAssetItems)' != 'true' ">
+		<ItemGroup>
+			<_UnoStaticWebAssetProjectConfiguration Include="@(StaticWebAssetProjectConfiguration)"  GetBuildAssetsTargets="_UnoAdjustGetCurrentProjectBuildStaticWebAssetItems"/>
+			<StaticWebAssetProjectConfiguration Remove="@(StaticWebAssetProjectConfiguration)" />
+			<StaticWebAssetProjectConfiguration Include="@(_UnoStaticWebAssetProjectConfiguration)" />
+		</ItemGroup>
+	</Target>
+
 </Project>

--- a/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
+++ b/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
@@ -429,15 +429,17 @@
 	</Target>
 
 	<!-- Workaround for https://github.com/unoplatform/Uno.Wasm.Bootstrap/issues/973 -->
-	<Target Name="_UnoAdjustOriginalItemSpecForProjectReference"
-			BeforeTargets="GetCurrentProjectBuildStaticWebAssetItems"
-			Condition=" $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '9.0.300')) and '$(UnoDisableAdjustOriginalItemSpecForProjectReference)' != 'true' ">  
+	<Target Name="_UnoAdjustGetCurrentProjectBuildStaticWebAssetItems"
+			DependsOnTargets="GetCurrentProjectBuildStaticWebAssetItems"
+			Returns="@(_CachedBuildStaticWebAssetItems)"
+			Condition=" $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '9.0.300')) and '$(UnoDisableGetCurrentProjectBuildStaticWebAssetItems)' != 'true' ">
+
 		<ItemGroup>
-			<_UnoCachedBuildStaticWebAssets Include="@(_CachedBuildStaticWebAssets)">
-				<OriginalItemSpec Condition="'%(_CachedBuildStaticWebAssets.OriginalItemSpec)' != ''">$([System.IO.Path]::GetFullPath('%(_CachedBuildStaticWebAssets.OriginalItemSpec)'))</OriginalItemSpec>
+			<_UnoCachedBuildStaticWebAssets Include="@(_CachedBuildStaticWebAssetItems)">
+				<OriginalItemSpec Condition="'%(_CachedBuildStaticWebAssetItems.OriginalItemSpec)' != ''">$([System.IO.Path]::GetFullPath('%(_CachedBuildStaticWebAssetItems.OriginalItemSpec)'))</OriginalItemSpec>
 			</_UnoCachedBuildStaticWebAssets>
-			<_CachedBuildStaticWebAssets Remove="@(_CachedBuildStaticWebAssets)" />
-			<_CachedBuildStaticWebAssets Include="@(_UnoCachedBuildStaticWebAssets)" />
+			<_CachedBuildStaticWebAssetItems Remove="@(_CachedBuildStaticWebAssetItems)" />
+			<_CachedBuildStaticWebAssetItems Include="@(_UnoCachedBuildStaticWebAssets)" />
 		</ItemGroup>
 	</Target>
 </Project>


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/Uno.Wasm.Bootstrap/issues/973

## What is the new behavior? 🚀

The previous fix (https://github.com/unoplatform/Uno.Wasm.Bootstrap/pull/974) was assuming that `_CachedBuildStaticWebAssetItems` were ambiently provided to the server project, but it may happen that `_CachedBuildStaticWebAssetItems` is not always populated.

This change moves from using `_CachedBuildStaticWebAssetItems` before it's generated by `GetCurrentProjectBuildStaticWebAssetItems` to after it's been generated. This is done by changing the targets of the msbuild invocation in `ResolveReferencedProjectsStaticWebAssets` so that it uses our target as the invocation output, instead of the original one.