### PR TITLE
docs: Add .NET 10 information to the bootstrap documentation

### DIFF
--- a/doc/using-the-bootstrapper.md
+++ b/doc/using-the-bootstrapper.md
@@ -175,6 +175,7 @@ Each major version of the bootstrapper targets a different version of the .NET R
 - 7.x: .NET 7 (https://github.com/dotnet/runtime/commits/release/7.0)
 - 8.0: .NET 8 (https://github.com/dotnet/runtime/commits/release/8.0)
 - 9.0: .NET 9 (https://github.com/dotnet/runtime/commits/release/9.0)
+- 10.0: .NET 10 (https://github.com/dotnet/runtime/commits/release/10.0)
 
 > [!NOTE]
 > Between version 3.x and 8.x, the bootstrapper is using custom builds of the runtime, maintained here: https://github.com/unoplatform/Uno.DotnetRuntime.WebAssembly


### PR DESCRIPTION
**GitHub Issue:** related to https://github.com/unoplatform/uno/issues/21766 and https://github.com/unoplatform/Uno.Wasm.Bootstrap/issues/986

## PR Type:

- 📚 Documentation content changes


## Description

Add .NET 10 information to the bootstrap documentation

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
