### PR TITLE
Fix invalid escaping of environment variables in uno-config.js

### DIFF
--- a/src/Uno.Wasm.Bootstrap.Server/build/Uno.Wasm.Bootstrap.Server.targets
+++ b/src/Uno.Wasm.Bootstrap.Server/build/Uno.Wasm.Bootstrap.Server.targets
@@ -1,20 +1,40 @@
 ﻿<Project>
 
 	<!--
-		`WriteFileVerbatimTask_v0` lives in `Uno.Wasm.Bootstrap.v0.dll`
-		(`src/Uno.Wasm.Bootstrap/WriteFileVerbatimTask.cs`). Server.targets is
-		consumed independently of Uno.Wasm.Bootstrap.targets, so we re-declare
-		the `<UsingTask>` here. The task DLL ships in both the Uno.Wasm.Bootstrap
-		and Uno.Wasm.Bootstrap.Server packages, so the file path is the same.
-		See the task source for why we cannot use `<WriteLinesToFile>` for the
-		uno-config.js fingerprint round-trip (MSBuild's item-value pipeline
-		normalises `\` to `/` and silently corrupts content that contains
-		backslashes that must be preserved).
+		`WriteFileVerbatimTask_v0` is declared inline here (via
+		`RoslynCodeTaskFactory`) rather than reused from
+		`Uno.Wasm.Bootstrap.v0.dll`: the Server nupkg does not pack that
+		task assembly, and Server.targets is consumed independently of
+		Uno.Wasm.Bootstrap.targets (by the ASP.NET Core host project, which
+		does not directly reference the WASM-side Bootstrap package). An
+		inline task keeps Server.targets self-contained without adding a
+		new packaged binary.
+
+		The companion task in `Uno.Wasm.Bootstrap` (see
+		`src/Uno.Wasm.Bootstrap/WriteFileVerbatimTask.cs`) documents why we
+		cannot use `<WriteLinesToFile>` for the uno-config.js fingerprint
+		round-trip: MSBuild's item-value pipeline normalises `\` to `/`
+		and silently corrupts content that contains backslashes that must
+		be preserved (e.g. JS `\"` escape sequences produced by
+		`ShellTask.GenerateConfig`).
 	-->
-	<PropertyGroup>
-		<_UnoServerBootstrapTaskBinary>$(MSBuildThisFileDirectory)../tools/Uno.Wasm.Bootstrap.v0.dll</_UnoServerBootstrapTaskBinary>
-	</PropertyGroup>
-	<UsingTask AssemblyFile="$(_UnoServerBootstrapTaskBinary)" TaskName="Uno.Wasm.Bootstrap.WriteFileVerbatimTask_v0" />
+	<UsingTask TaskName="WriteFileVerbatimTask_v0"
+			   TaskFactory="RoslynCodeTaskFactory"
+			   AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+		<ParameterGroup>
+			<Path ParameterType="System.String" Required="True" />
+			<Content ParameterType="System.String" Required="True" />
+		</ParameterGroup>
+		<Task>
+			<Using Namespace="System.IO" />
+			<Using Namespace="System.Text" />
+			<Code Type="Fragment" Language="cs">
+				<![CDATA[
+					File.WriteAllText(Path, Content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+				]]>
+			</Code>
+		</Task>
+	</UsingTask>
 
 	<!-- Workaround for https://github.com/unoplatform/Uno.Wasm.Bootstrap/issues/973 -->
 	<Target Name="_UnoAdjustResolveReferencedProjectsStaticWebAssetsConfiguration"

--- a/src/Uno.Wasm.Bootstrap.Server/build/Uno.Wasm.Bootstrap.Server.targets
+++ b/src/Uno.Wasm.Bootstrap.Server/build/Uno.Wasm.Bootstrap.Server.targets
@@ -1,5 +1,21 @@
 ﻿<Project>
 
+	<!--
+		`WriteFileVerbatimTask_v0` lives in `Uno.Wasm.Bootstrap.v0.dll`
+		(`src/Uno.Wasm.Bootstrap/WriteFileVerbatimTask.cs`). Server.targets is
+		consumed independently of Uno.Wasm.Bootstrap.targets, so we re-declare
+		the `<UsingTask>` here. The task DLL ships in both the Uno.Wasm.Bootstrap
+		and Uno.Wasm.Bootstrap.Server packages, so the file path is the same.
+		See the task source for why we cannot use `<WriteLinesToFile>` for the
+		uno-config.js fingerprint round-trip (MSBuild's item-value pipeline
+		normalises `\` to `/` and silently corrupts content that contains
+		backslashes that must be preserved).
+	-->
+	<PropertyGroup>
+		<_UnoServerBootstrapTaskBinary>$(MSBuildThisFileDirectory)../tools/Uno.Wasm.Bootstrap.v0.dll</_UnoServerBootstrapTaskBinary>
+	</PropertyGroup>
+	<UsingTask AssemblyFile="$(_UnoServerBootstrapTaskBinary)" TaskName="Uno.Wasm.Bootstrap.WriteFileVerbatimTask_v0" />
+
 	<!-- Workaround for https://github.com/unoplatform/Uno.Wasm.Bootstrap/issues/973 -->
 	<Target Name="_UnoAdjustResolveReferencedProjectsStaticWebAssetsConfiguration"
 			AfterTargets="ResolveReferencedProjectsStaticWebAssetsConfiguration"
@@ -57,11 +73,14 @@
 				 Text="[Uno.Server] Updating uno-config.js at: $(_UnoServerConfigJsPath)"
 				 Condition="'$(_UnoServerActualDotnetJsFingerprint)' != '' AND '$(_UnoServerConfigJsPath)' != '' AND Exists('$(_UnoServerConfigJsPath)')" />
 
-		<!-- Update uno-config.js in the server publish output with the actual fingerprint -->
-		<WriteLinesToFile
-			File="$(_UnoServerConfigJsPath)"
-			Lines="$([System.Text.RegularExpressions.Regex]::Replace($([System.Text.RegularExpressions.Regex]::Replace($([System.IO.File]::ReadAllText('$(_UnoServerConfigJsPath)')), 'config\.dotnet_js_filename = &quot;dotnet(\.[^&quot;]+)?\.js&quot;', 'config.dotnet_js_filename = &quot;dotnet.$(_UnoServerActualDotnetJsFingerprint).js&quot;')), '_framework/dotnet(\.[^&quot;]+)?\.js', '_framework/dotnet.$(_UnoServerActualDotnetJsFingerprint).js'))"
-			Overwrite="true"
+		<!--
+			Update uno-config.js in the server publish output with the actual
+			fingerprint. See the `WriteFileVerbatimTask_v0` doc at the top of
+			this file for why we use it here instead of `<WriteLinesToFile>`.
+		-->
+		<WriteFileVerbatimTask_v0
+			Path="$(_UnoServerConfigJsPath)"
+			Content="$([System.Text.RegularExpressions.Regex]::Replace($([System.Text.RegularExpressions.Regex]::Replace($([System.IO.File]::ReadAllText('$(_UnoServerConfigJsPath)')), 'config\.dotnet_js_filename = &quot;dotnet(\.[^&quot;]+)?\.js&quot;', 'config.dotnet_js_filename = &quot;dotnet.$(_UnoServerActualDotnetJsFingerprint).js&quot;')), '_framework/dotnet(\.[^&quot;]+)?\.js', '_framework/dotnet.$(_UnoServerActualDotnetJsFingerprint).js'))"
 			Condition="'$(_UnoServerActualDotnetJsFingerprint)' != '' AND '$(_UnoServerConfigJsPath)' != '' AND Exists('$(_UnoServerConfigJsPath)')" />
 
 		<Message Importance="normal"

--- a/src/Uno.Wasm.Bootstrap.UnitTests/Given_ShellTask_EnvironmentVariableEscaping.cs
+++ b/src/Uno.Wasm.Bootstrap.UnitTests/Given_ShellTask_EnvironmentVariableEscaping.cs
@@ -39,5 +39,32 @@ namespace Uno.Wasm.Bootstrap.UnitTests
 			var result = JsStringHelper.EscapeJsString(input);
 			Assert.AreEqual(expected, result);
 		}
+
+		// Regression: even though `EscapeJsString` correctly produces `\"`
+		// for `"`, the build pipeline used to corrupt that into `/"` when
+		// the uno-config.js fingerprint update target round-tripped the
+		// file through MSBuild's `<WriteLinesToFile>`. The MSBuild item-
+		// value pipeline normalised backslashes to forward slashes
+		// (treating them as path separators), turning legitimate JS
+		// escapes into invalid syntax that broke bootstrap loading with
+		// `SyntaxError: Unexpected identifier <next-token>` against
+		// whatever identifier followed the prematurely-terminated string
+		// literal.
+		//
+		// The fix replaced `<WriteLinesToFile>` with `WriteFileVerbatimTask_v0`
+		// (a real task that writes via `System.IO.File.WriteAllText`), whose
+		// `string`-typed parameters bypass the item-value pipeline and
+		// preserve bytes verbatim. This test asserts the contract
+		// `EscapeJsString` must satisfy for that downstream round-trip to
+		// remain correct.
+		[TestMethod]
+		public void When_EscapeJsString_Then_OutputContainsLiteralBackslash()
+		{
+			var result = JsStringHelper.EscapeJsString("hello\"world");
+
+			Assert.AreEqual("hello\\\"world", result, "EscapeJsString must produce backslash-quote for an input quote.");
+			Assert.IsFalse(result.Contains('/'), "EscapeJsString output must not introduce forward slashes (downstream targets must preserve bytes verbatim).");
+			Assert.IsTrue(result.Contains('\\'), "Expected literal backslash in the escaped output.");
+		}
 	}
 }

--- a/src/Uno.Wasm.Bootstrap.UnitTests/Given_ShellTask_EnvironmentVariableEscaping.cs
+++ b/src/Uno.Wasm.Bootstrap.UnitTests/Given_ShellTask_EnvironmentVariableEscaping.cs
@@ -63,8 +63,6 @@ namespace Uno.Wasm.Bootstrap.UnitTests
 			var result = JsStringHelper.EscapeJsString("hello\"world");
 
 			Assert.AreEqual("hello\\\"world", result, "EscapeJsString must produce backslash-quote for an input quote.");
-			Assert.IsFalse(result.Contains('/'), "EscapeJsString output must not introduce forward slashes (downstream targets must preserve bytes verbatim).");
-			Assert.IsTrue(result.Contains('\\'), "Expected literal backslash in the escaped output.");
 		}
 	}
 }

--- a/src/Uno.Wasm.Bootstrap/WriteFileVerbatimTask.cs
+++ b/src/Uno.Wasm.Bootstrap/WriteFileVerbatimTask.cs
@@ -1,0 +1,68 @@
+// ******************************************************************
+// Copyright © 2015-2026 Uno Platform inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ******************************************************************
+
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Uno.Wasm.Bootstrap;
+
+/// <summary>
+/// Writes <see cref="Content"/> verbatim (UTF-8, no BOM) to <see cref="Path"/>.
+/// </summary>
+/// <remarks>
+/// Used in place of the built-in <c>WriteLinesToFile</c> task when the content
+/// to be written may contain backslash characters that must be preserved.
+/// <para>
+/// <c>WriteLinesToFile.Lines</c> is typed as <c>ITaskItem[]</c>, so passing
+/// content through it routes the value through MSBuild's item-value pipeline.
+/// That pipeline normalises backslash (<c>\</c>) to forward slash (<c>/</c>)
+/// as if treating it as a path separator, which silently corrupts any
+/// non-path content that legitimately uses backslashes — for example, JS
+/// string literals containing <c>\"</c> escape sequences. The resulting
+/// <c>/"</c> terminates the literal prematurely and produces invalid JS.
+/// </para>
+/// <para>
+/// A <see cref="string"/>-typed parameter on a real task (this class)
+/// bypasses the item-list pipeline and is delivered to the task verbatim,
+/// so every byte of <see cref="Content"/> lands on disk unchanged.
+/// </para>
+/// </remarks>
+public class WriteFileVerbatimTask_v0 : Microsoft.Build.Utilities.Task
+{
+	/// <summary>
+	/// Destination file path. Parent directories must already exist.
+	/// </summary>
+	[Required]
+	public string Path { get; set; } = "";
+
+	/// <summary>
+	/// File content. Written verbatim as UTF-8 without a BOM.
+	/// </summary>
+	[Required]
+	public string Content { get; set; } = "";
+
+	public override bool Execute()
+	{
+		// UTF-8 with no BOM matches what ShellTask uses when it first writes
+		// uno-config.js, so a round-trip through this task doesn't introduce
+		// a stray BOM that downstream tooling (asset fingerprinting, pre-
+		// compression) would otherwise have to tolerate.
+		File.WriteAllText(Path, Content, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+		return true;
+	}
+}

--- a/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
+++ b/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
@@ -315,11 +315,13 @@
 	<UsingTask Condition="!$(_WasmShellTasksPathIsDevMode)" AssemblyFile="$(WasmShellTasksPath)/Uno.Wasm.Bootstrap.v0.dll" TaskName="Uno.Wasm.Bootstrap.GenerateUnoAssetsManifest_v0" />
 	<UsingTask Condition="!$(_WasmShellTasksPathIsDevMode)" AssemblyFile="$(WasmShellTasksPath)/Uno.Wasm.Bootstrap.v0.dll" TaskName="Uno.Wasm.Bootstrap.StaticWebAssetsResolverTask_v0" />
 	<UsingTask Condition="!$(_WasmShellTasksPathIsDevMode)" AssemblyFile="$(WasmShellTasksPath)/Uno.Wasm.Bootstrap.v0.dll" TaskName="Uno.Wasm.Bootstrap.GenerateUnoNativeAssetsTask_v0" />
+	<UsingTask Condition="!$(_WasmShellTasksPathIsDevMode)" AssemblyFile="$(WasmShellTasksPath)/Uno.Wasm.Bootstrap.v0.dll" TaskName="Uno.Wasm.Bootstrap.WriteFileVerbatimTask_v0" />
 
 	<UsingTask Condition="$(_WasmShellTasksPathIsDevMode)" AssemblyFile="$(WasmShellTasksPath)/Uno.Wasm.Bootstrap.v0.dll" TaskName="Uno.Wasm.Bootstrap.ShellTask_v0" TaskFactory="TaskHostFactory" />
 	<UsingTask Condition="$(_WasmShellTasksPathIsDevMode)" AssemblyFile="$(WasmShellTasksPath)/Uno.Wasm.Bootstrap.v0.dll" TaskName="Uno.Wasm.Bootstrap.GenerateUnoAssetsManifest_v0" TaskFactory="TaskHostFactory" />
 	<UsingTask Condition="$(_WasmShellTasksPathIsDevMode)" AssemblyFile="$(WasmShellTasksPath)/Uno.Wasm.Bootstrap.v0.dll" TaskName="Uno.Wasm.Bootstrap.StaticWebAssetsResolverTask_v0" TaskFactory="TaskHostFactory" />
 	<UsingTask Condition="$(_WasmShellTasksPathIsDevMode)" AssemblyFile	="$(WasmShellTasksPath)/Uno.Wasm.Bootstrap.v0.dll" TaskName="Uno.Wasm.Bootstrap.GenerateUnoNativeAssetsTask_v0" TaskFactory="TaskHostFactory" />
+	<UsingTask Condition="$(_WasmShellTasksPathIsDevMode)" AssemblyFile="$(WasmShellTasksPath)/Uno.Wasm.Bootstrap.v0.dll" TaskName="Uno.Wasm.Bootstrap.WriteFileVerbatimTask_v0" TaskFactory="TaskHostFactory" />
 
 	<PropertyGroup>
 		<UnoGenerateAssetsManifestDependsOn>
@@ -500,11 +502,24 @@
 			<_UnoConfigJsPath>$(IntermediateOutputPath)unowwwrootassets/uno-config.js</_UnoConfigJsPath>
 		</PropertyGroup>
 
-		<!-- Update the uno-config.js file with the fingerprinted filename if we found a fingerprint -->
-		<WriteLinesToFile
-			File="$(_UnoConfigJsPath)"
-			Lines="$([System.IO.File]::ReadAllText('$(_UnoConfigJsPath)').Replace('config.dotnet_js_filename = &quot;dotnet.js&quot;', 'config.dotnet_js_filename = &quot;dotnet.$(_UnoDotnetJsFingerprint).js&quot;').Replace('_framework/dotnet.js', '_framework/dotnet.$(_UnoDotnetJsFingerprint).js'))"
-			Overwrite="true"
+		<!--
+			Update the uno-config.js file with the fingerprinted filename if we
+			found a fingerprint. We use `WriteFileVerbatimTask_v0` rather than
+			the built-in `<WriteLinesToFile>` because the latter's `Lines`
+			parameter is `ITaskItem[]`, which routes the content through
+			MSBuild's item-value pipeline. That pipeline normalises backslash
+			(`\`) to forward slash (`/`) — treating them as path separators —
+			and silently corrupts any legitimate `\"` escape sequence emitted
+			by `ShellTask.GenerateConfig` for environment-variable values that
+			contain a double quote. The resulting `/"` terminates the JS string
+			literal prematurely and the bootstrap fails to load with
+			`SyntaxError: Unexpected identifier <whatever-followed>`. A
+			`string`-typed task parameter on a real task bypasses the item-list
+			pipeline and preserves bytes verbatim.
+		-->
+		<WriteFileVerbatimTask_v0
+			Path="$(_UnoConfigJsPath)"
+			Content="$([System.IO.File]::ReadAllText('$(_UnoConfigJsPath)').Replace('config.dotnet_js_filename = &quot;dotnet.js&quot;', 'config.dotnet_js_filename = &quot;dotnet.$(_UnoDotnetJsFingerprint).js&quot;').Replace('_framework/dotnet.js', '_framework/dotnet.$(_UnoDotnetJsFingerprint).js'))"
 			Condition="'$(_UnoDotnetJsFingerprint)' != '' AND Exists('$(_UnoConfigJsPath)')" />
 	</Target>
 
@@ -555,11 +570,15 @@
 		<Warning Text="[Uno] Could not find uno-config.js at: $(_UnoPublishConfigJsPath)"
 				 Condition="'$(_UnoActualDotnetJsFingerprint)' != '' AND !Exists('$(_UnoPublishConfigJsPath)')" />
 
-		<!-- Update uno-config.js in the publish output with the actual fingerprint -->
-		<WriteLinesToFile
-			File="$(_UnoPublishConfigJsPath)"
-			Lines="$([System.Text.RegularExpressions.Regex]::Replace($([System.Text.RegularExpressions.Regex]::Replace($([System.IO.File]::ReadAllText('$(_UnoPublishConfigJsPath)')), 'config\.dotnet_js_filename = &quot;dotnet(\.[^&quot;]+)?\.js&quot;', 'config.dotnet_js_filename = &quot;dotnet.$(_UnoActualDotnetJsFingerprint).js&quot;')), '_framework/dotnet(\.[^&quot;]+)?\.js', '_framework/dotnet.$(_UnoActualDotnetJsFingerprint).js'))"
-			Overwrite="true"
+		<!--
+			Update uno-config.js in the publish output with the actual
+			fingerprint. See the `WriteFileVerbatimTask_v0` rationale in the
+			build-time target above — the same MSBuild item-value `\` → `/`
+			corruption applies here.
+		-->
+		<WriteFileVerbatimTask_v0
+			Path="$(_UnoPublishConfigJsPath)"
+			Content="$([System.Text.RegularExpressions.Regex]::Replace($([System.Text.RegularExpressions.Regex]::Replace($([System.IO.File]::ReadAllText('$(_UnoPublishConfigJsPath)')), 'config\.dotnet_js_filename = &quot;dotnet(\.[^&quot;]+)?\.js&quot;', 'config.dotnet_js_filename = &quot;dotnet.$(_UnoActualDotnetJsFingerprint).js&quot;')), '_framework/dotnet(\.[^&quot;]+)?\.js', '_framework/dotnet.$(_UnoActualDotnetJsFingerprint).js'))"
 			Condition="'$(_UnoActualDotnetJsFingerprint)' != '' AND Exists('$(_UnoPublishConfigJsPath)')" />
 
 		<!--
@@ -951,10 +970,15 @@
 			<_UnoWorkerConfigJs Include="$(_UnoWorkerDestRoot)/**/uno-config.js" />
 		</ItemGroup>
 
-		<WriteLinesToFile
-			File="%(_UnoWorkerConfigJs.Identity)"
-			Lines="$([System.Text.RegularExpressions.Regex]::Replace($([System.Text.RegularExpressions.Regex]::Replace($([System.IO.File]::ReadAllText('%(_UnoWorkerConfigJs.Identity)')), 'config\.dotnet_js_filename = &quot;dotnet(\.[^&quot;]+)?\.js&quot;', 'config.dotnet_js_filename = &quot;dotnet.$(_UnoWorkerDotnetJsFingerprint).js&quot;')), '_framework/dotnet(\.[^&quot;]+)?\.js', '_framework/dotnet.$(_UnoWorkerDotnetJsFingerprint).js'))"
-			Overwrite="true"
+		<!--
+			Update the worker's uno-config.js fingerprint. Same MSBuild
+			item-value `\` → `/` corruption rationale as the host-side
+			fingerprint update — see the comment block on the first
+			`WriteFileVerbatimTask_v0` invocation in this file.
+		-->
+		<WriteFileVerbatimTask_v0
+			Path="%(_UnoWorkerConfigJs.Identity)"
+			Content="$([System.Text.RegularExpressions.Regex]::Replace($([System.Text.RegularExpressions.Regex]::Replace($([System.IO.File]::ReadAllText('%(_UnoWorkerConfigJs.Identity)')), 'config\.dotnet_js_filename = &quot;dotnet(\.[^&quot;]+)?\.js&quot;', 'config.dotnet_js_filename = &quot;dotnet.$(_UnoWorkerDotnetJsFingerprint).js&quot;')), '_framework/dotnet(\.[^&quot;]+)?\.js', '_framework/dotnet.$(_UnoWorkerDotnetJsFingerprint).js'))"
 			Condition="'$(_UnoWorkerDotnetJsFingerprint)' != '' AND '@(_UnoWorkerConfigJs)' != ''" />
 
 		<!-- Delete stale compressed versions of uno-config.js -->


### PR DESCRIPTION
Introduce WriteFileVerbatimTask_v0 to preserve backslashes in file writes and update uno-config.js handling