### PR TITLE
chore: use Mono.Cecil 0.11.6

### DIFF
--- a/src/Uno.Wasm.Bootstrap/Uno.Wasm.Bootstrap.csproj
+++ b/src/Uno.Wasm.Bootstrap/Uno.Wasm.Bootstrap.csproj
@@ -13,6 +13,7 @@
 		<Nullable>enable</Nullable>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<IsPublishable>false</IsPublishable>
+		<_MonoCecilPackageVersion>0.11.6</_MonoCecilPackageVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(NBGV_GitCommitId)'!=''">
@@ -33,7 +34,7 @@
 		<PackageReference Include="Microsoft.Build.Framework" Version="15.3.409" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.3.409" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.3.409" PrivateAssets="All" />
-		<PackageReference Include="Mono.Cecil" Version="0.11.4" PrivateAssets="All" />
+		<PackageReference Include="Mono.Cecil" Version="$(_MonoCecilPackageVersion)" PrivateAssets="All" />
 		<PackageReference Include="Mono.Options" Version="5.3.0.1" PrivateAssets="All" />
 		<PackageReference Include="MSBuildTasks" Version="1.5.0.235" PrivateAssets="All" />
 		<PackageReference Include="System.Text.Json" Version="8.0.5" PrivateAssets="All" />
@@ -58,7 +59,7 @@
 			<PackagePath>tools/templates</PackagePath>
 		</None>
 
-		<None Include="$(NuGetPackageRoot)/mono.cecil/0.11.4/lib/netstandard2.0/*.dll">
+		<None Include="$(NuGetPackageRoot)/mono.cecil/$(_MonoCecilPackageVersion)/lib/netstandard2.0/*.dll">
 			<Pack>true</Pack>
 			<PackagePath>tools</PackagePath>
 			<Visible>false</Visible>
@@ -78,7 +79,7 @@
 			pick them up as transitive output content
 		-->
 		<ItemGroup>
-			<_UnoTaskDependencies Include="$(NuGetPackageRoot)/mono.cecil/0.11.4/lib/netstandard2.0/*.dll" />
+			<_UnoTaskDependencies Include="$(NuGetPackageRoot)/mono.cecil/$(_MonoCecilPackageVersion)/lib/netstandard2.0/*.dll" />
 			<_UnoTaskDependencies Include="$(NuGetPackageRoot)/newtonsoft.json/13.0.2/lib/netstandard2.0/*.dll" />
 		</ItemGroup>
 		<Copy SourceFiles="@(_UnoTaskDependencies)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" />

--- a/src/Uno.Wasm.Bootstrap/Uno.Wasm.Bootstrap.csproj
+++ b/src/Uno.Wasm.Bootstrap/Uno.Wasm.Bootstrap.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<DefineConstants>NET_CORE</DefineConstants>
-		<NoWarn>1701;1702;1705;649;NU5128;NU1903</NoWarn>
+		<NoWarn>1701;1702;1705;649;NU5128</NoWarn>
 		<AssemblyName>Uno.Wasm.Bootstrap.v0</AssemblyName>
 		<RootNamespace>Uno.Wasm.Bootstrap.v0</RootNamespace>
 		<PackageId>Uno.Wasm.Bootstrap</PackageId>

--- a/src/Uno.Wasm.VersionChecker.Core/Uno.Wasm.VersionChecker.Core.csproj
+++ b/src/Uno.Wasm.VersionChecker.Core/Uno.Wasm.VersionChecker.Core.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="HtmlAgilityPack" Version="1.11.34" />
-		<PackageReference Include="Mono.Cecil" Version="0.11.3" />
+		<PackageReference Include="Mono.Cecil" Version="0.11.6" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Context: https://github.com/unoplatform/uno/pull/24050

In some scenarios, Mono.Cecil will corrupt a `.pdb`; see unoplatform/uno#24050 for details.

Bump to Mono.Cecil 0.11.6, which fixes this issue.

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

- 🏗️ Build or CI related changes

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->